### PR TITLE
Add interactive atlas and expand Dreamless Kingdom entries

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -7,6 +7,24 @@ const state = {
   tag: 'All',
 };
 
+function renderMapMarkers(){
+  const map = document.querySelector('#map');
+  if(!map) return;
+  map.innerHTML = '';
+  const filteredIds = new Set(state.filtered.map(e=>e.id));
+  state.entries.filter(e=>e.location).forEach(e=>{
+    const marker = document.createElement('button');
+    marker.className = 'marker' + (filteredIds.has(e.id) ? '' : ' dim');
+    marker.style.left = `${e.location.x}%`;
+    marker.style.top = `${e.location.y}%`;
+    marker.setAttribute('aria-label', `${e.title} — ${e.location.region||'Unknown region'}`);
+    marker.title = `${e.title}\n${e.location.region||'Unknown region'}`;
+    marker.innerHTML = '<span></span>';
+    marker.addEventListener('click', ()=>openModal(e));
+    map.appendChild(marker);
+  });
+}
+
 function normalize(s) { return (s||'').toLowerCase(); }
 
 function generateHooks(e) {
@@ -39,6 +57,7 @@ function applyFilters() {
   });
   renderGrid();
   renderCount();
+  renderMapMarkers();
 }
 
 function renderCount(){
@@ -82,12 +101,16 @@ function openModal(e){
   const modal = document.querySelector('#modal');
   const body = modal.querySelector('.body');
   const hooks = generateHooks(e);
+  const region = e.location?.region;
+  const coords = e.location ? `${e.location.x.toFixed(1)}%, ${e.location.y.toFixed(1)}%` : null;
   body.innerHTML = `
     <div class="kv">
       <div>World</div><div>Dreamless Kingdom</div>
       <div>Category</div><div>${e.category||'Entry'}</div>
       <div>Tag</div><div>${e.tag}</div>
+      ${region ? `<div>Region</div><div>${region}</div>` : ''}
       <div>ID</div><div><code>${e.id}</code></div>
+      ${coords ? `<div>Map Coordinates</div><div>${coords}</div>` : ''}
     </div>
     <hr/>
     <p>${e.summary}</p>
@@ -125,6 +148,7 @@ async function main(){
   renderTags();
   applyFilters();
   restoreFromHash();
+  renderMapMarkers();
 }
 
 window.addEventListener('hashchange', restoreFromHash);

--- a/assets/style.css
+++ b/assets/style.css
@@ -22,6 +22,20 @@ button:hover{border-color:var(--accent)}
 .hidden{display:none}
 .badge{border:1px solid var(--line);background:var(--panel);padding:6px 10px;border-radius:999px;color:var(--muted);font-size:12px}
 .badge.active{border-color:var(--accent);color:var(--ink)}
+.map-wrapper{margin:28px 0;background:linear-gradient(135deg,#10182b,#181f33);border:1px solid var(--line);border-radius:24px;padding:20px;box-shadow:0 14px 32px rgba(0,0,0,.25)}
+.map-header{display:flex;flex-direction:column;gap:4px;margin-bottom:16px}
+.map-header h2{margin:0;font-size:20px}
+.map{position:relative;width:100%;padding-top:62%;border:1px solid var(--line);border-radius:18px;background:radial-gradient(circle at 30% 20%, rgba(224,177,65,.25), transparent 45%), radial-gradient(circle at 70% 70%, rgba(111,203,255,.18), transparent 50%), linear-gradient(160deg,#0f1524,#12192a 40%,#10152b 100%);overflow:hidden}
+.map::after{content:'';position:absolute;inset:0;background-image:linear-gradient(0deg,rgba(255,255,255,.05) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.05) 1px,transparent 1px);background-size:14% 14%;opacity:.35;pointer-events:none}
+.marker{position:absolute;transform:translate(-50%,-50%);width:18px;height:18px;border-radius:50%;border:2px solid rgba(255,255,255,.8);background:var(--accent);box-shadow:0 0 0 0 rgba(224,177,65,.6);animation:pulse 3s infinite;cursor:pointer;display:grid;place-items:center}
+.marker:focus-visible{outline:2px solid #fff;outline-offset:2px}
+.marker span{position:absolute;width:6px;height:6px;border-radius:50%;background:#121622}
+.marker.dim{background:rgba(147,152,172,.65);border-color:rgba(211,214,224,.4);box-shadow:none;animation:none}
+.map-legend{display:flex;gap:16px;flex-wrap:wrap;margin-top:14px;color:var(--muted)}
+.legend-item{display:inline-flex;align-items:center;gap:6px}
+.legend-dot{width:10px;height:10px;border-radius:50%;background:var(--accent);border:1px solid rgba(255,255,255,.8)}
+.legend-dot.dim{background:rgba(147,152,172,.65);border-color:rgba(211,214,224,.4)}
+@keyframes pulse{0%{box-shadow:0 0 0 0 rgba(224,177,65,.6)}70%{box-shadow:0 0 0 14px rgba(224,177,65,0)}100%{box-shadow:0 0 0 0 rgba(224,177,65,0)}}
 .modal{position:fixed;inset:0;display:none;background:rgba(0,0,0,.55);place-items:center;padding:16px}
 .modal.open{display:grid}
 .sheet{max-width:760px;width:100%;background:var(--panel);border:1px solid var(--line);border-radius:20px;overflow:hidden}

--- a/data/entries.json
+++ b/data/entries.json
@@ -8,56 +8,96 @@
       "title": "Perfumer's Incense",
       "summary": "Attracts rare creatures and grants passage past the forest guardians. Crafted from mint, memory, and longing.",
       "tag": "Key Item",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 18, "y": 36, "region": "Whispering Arboretum" }
     },
     {
       "id": "power-belt",
       "title": "Power Belt",
       "summary": "A prototype meant to make labor lighter. Opens the Carnival gates and moves the forest boulder blocking Deep Mines access.",
       "tag": "Key Item",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 52, "y": 68, "region": "Carnival Quarter" }
     },
     {
       "id": "manifestos",
       "title": "Lost Manifestos (I-III)",
       "summary": "Forbidden texts that reveal the true liturgy hidden behind the Palace's gold trim and pretense. Truth that needs no sermon, only a vessel.",
       "tag": "Quest Item",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 64, "y": 24, "region": "Gilt Palace" }
     },
     {
       "id": "dreamroot",
       "title": "Dreamroot",
       "summary": "A rare plant that may restore the ability to dream. Sought by those who remember what sleeping used to mean.",
       "tag": "Rare Material",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 28, "y": 60, "region": "Verdant Hollows" }
     },
     {
       "id": "sparkling-mineral",
       "title": "Sparkling Mineral",
       "summary": "Hidden deep below, once dreamed of by the Taskmaster. Reminds builders how to construct with hope instead of mere order.",
       "tag": "Crafting Material",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 80, "y": 72, "region": "Deep Mines" }
     },
     {
       "id": "golden-cap",
       "title": "Golden Cap Sphere",
       "summary": "Alchemical creation that clears mind fog. Brewed from Honeyglobe Capsules and memories of clearer times.",
       "tag": "Consumable",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 45, "y": 48, "region": "Alchemists' Span" }
     },
     {
       "id": "blooming-robes",
       "title": "Blooming Robes",
       "summary": "Discarded Choir vestments where spores took root. They bloom beautifully, telling secrets in fungal rhythms.",
       "tag": "Trade Item",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 35, "y": 22, "region": "Choir Ruins" }
     },
     {
       "id": "lost-camera",
       "title": "Lost Camera",
       "summary": "Found in the mines, traded by the Gatherer. Helps the Sporeborn capture the beauty they see in darkness.",
       "tag": "Quest Item",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 86, "y": 55, "region": "Subterranean Galleries" }
+    },
+    {
+      "id": "starwoven-compass",
+      "title": "Starwoven Compass",
+      "summary": "A lattice of meteor-thread that points toward the last place someone felt truly at peace. Revered by cloud-sailors.",
+      "tag": "Key Item",
+      "category": "Relic",
+      "location": { "x": 12, "y": 18, "region": "Skybreak Ridge" }
+    },
+    {
+      "id": "echo-lantern",
+      "title": "Echo Lantern",
+      "summary": "Lantern that remembers voices it hears and replays them as guiding harmonies within the dusk-tunnels.",
+      "tag": "Utility",
+      "category": "Item",
+      "location": { "x": 58, "y": 82, "region": "Dusk Tunnels" }
+    },
+    {
+      "id": "choral-seed",
+      "title": "Choral Seed Reliquary",
+      "summary": "A seed pod humming with dormant choir notes. Planting it awakens protective hymns around a campsite.",
+      "tag": "Defensive",
+      "category": "Artifact",
+      "location": { "x": 42, "y": 30, "region": "Resonant Plaza" }
+    },
+    {
+      "id": "tideturn-vial",
+      "title": "Tideturn Vial",
+      "summary": "Captures one ebb of the underground sea. When shattered, it reverses gravity for a heartbeat.",
+      "tag": "Consumable",
+      "category": "Alchemical",
+      "location": { "x": 76, "y": 40, "region": "Undersea Observatory" }
     }
   ]
 }

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -7,6 +7,24 @@ const state = {
   tag: 'All',
 };
 
+function renderMapMarkers(){
+  const map = document.querySelector('#map');
+  if(!map) return;
+  map.innerHTML = '';
+  const filteredIds = new Set(state.filtered.map(e=>e.id));
+  state.entries.filter(e=>e.location).forEach(e=>{
+    const marker = document.createElement('button');
+    marker.className = 'marker' + (filteredIds.has(e.id) ? '' : ' dim');
+    marker.style.left = `${e.location.x}%`;
+    marker.style.top = `${e.location.y}%`;
+    marker.setAttribute('aria-label', `${e.title} — ${e.location.region||'Unknown region'}`);
+    marker.title = `${e.title}\n${e.location.region||'Unknown region'}`;
+    marker.innerHTML = '<span></span>';
+    marker.addEventListener('click', ()=>openModal(e));
+    map.appendChild(marker);
+  });
+}
+
 function normalize(s) { return (s||'').toLowerCase(); }
 
 function generateHooks(e) {
@@ -39,6 +57,7 @@ function applyFilters() {
   });
   renderGrid();
   renderCount();
+  renderMapMarkers();
 }
 
 function renderCount(){
@@ -82,12 +101,16 @@ function openModal(e){
   const modal = document.querySelector('#modal');
   const body = modal.querySelector('.body');
   const hooks = generateHooks(e);
+  const region = e.location?.region;
+  const coords = e.location ? `${e.location.x.toFixed(1)}%, ${e.location.y.toFixed(1)}%` : null;
   body.innerHTML = `
     <div class="kv">
       <div>World</div><div>Dreamless Kingdom</div>
       <div>Category</div><div>${e.category||'Entry'}</div>
       <div>Tag</div><div>${e.tag}</div>
+      ${region ? `<div>Region</div><div>${region}</div>` : ''}
       <div>ID</div><div><code>${e.id}</code></div>
+      ${coords ? `<div>Map Coordinates</div><div>${coords}</div>` : ''}
     </div>
     <hr/>
     <p>${e.summary}</p>
@@ -125,6 +148,7 @@ async function main(){
   renderTags();
   applyFilters();
   restoreFromHash();
+  renderMapMarkers();
 }
 
 window.addEventListener('hashchange', restoreFromHash);

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -22,6 +22,20 @@ button:hover{border-color:var(--accent)}
 .hidden{display:none}
 .badge{border:1px solid var(--line);background:var(--panel);padding:6px 10px;border-radius:999px;color:var(--muted);font-size:12px}
 .badge.active{border-color:var(--accent);color:var(--ink)}
+.map-wrapper{margin:28px 0;background:linear-gradient(135deg,#10182b,#181f33);border:1px solid var(--line);border-radius:24px;padding:20px;box-shadow:0 14px 32px rgba(0,0,0,.25)}
+.map-header{display:flex;flex-direction:column;gap:4px;margin-bottom:16px}
+.map-header h2{margin:0;font-size:20px}
+.map{position:relative;width:100%;padding-top:62%;border:1px solid var(--line);border-radius:18px;background:radial-gradient(circle at 30% 20%, rgba(224,177,65,.25), transparent 45%), radial-gradient(circle at 70% 70%, rgba(111,203,255,.18), transparent 50%), linear-gradient(160deg,#0f1524,#12192a 40%,#10152b 100%);overflow:hidden}
+.map::after{content:'';position:absolute;inset:0;background-image:linear-gradient(0deg,rgba(255,255,255,.05) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.05) 1px,transparent 1px);background-size:14% 14%;opacity:.35;pointer-events:none}
+.marker{position:absolute;transform:translate(-50%,-50%);width:18px;height:18px;border-radius:50%;border:2px solid rgba(255,255,255,.8);background:var(--accent);box-shadow:0 0 0 0 rgba(224,177,65,.6);animation:pulse 3s infinite;cursor:pointer;display:grid;place-items:center}
+.marker:focus-visible{outline:2px solid #fff;outline-offset:2px}
+.marker span{position:absolute;width:6px;height:6px;border-radius:50%;background:#121622}
+.marker.dim{background:rgba(147,152,172,.65);border-color:rgba(211,214,224,.4);box-shadow:none;animation:none}
+.map-legend{display:flex;gap:16px;flex-wrap:wrap;margin-top:14px;color:var(--muted)}
+.legend-item{display:inline-flex;align-items:center;gap:6px}
+.legend-dot{width:10px;height:10px;border-radius:50%;background:var(--accent);border:1px solid rgba(255,255,255,.8)}
+.legend-dot.dim{background:rgba(147,152,172,.65);border-color:rgba(211,214,224,.4)}
+@keyframes pulse{0%{box-shadow:0 0 0 0 rgba(224,177,65,.6)}70%{box-shadow:0 0 0 14px rgba(224,177,65,0)}100%{box-shadow:0 0 0 0 rgba(224,177,65,0)}}
 .modal{position:fixed;inset:0;display:none;background:rgba(0,0,0,.55);place-items:center;padding:16px}
 .modal.open{display:grid}
 .sheet{max-width:760px;width:100%;background:var(--panel);border:1px solid var(--line);border-radius:20px;overflow:hidden}

--- a/docs/data/entries.json
+++ b/docs/data/entries.json
@@ -8,56 +8,96 @@
       "title": "Perfumer's Incense",
       "summary": "Attracts rare creatures and grants passage past the forest guardians. Crafted from mint, memory, and longing.",
       "tag": "Key Item",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 18, "y": 36, "region": "Whispering Arboretum" }
     },
     {
       "id": "power-belt",
       "title": "Power Belt",
       "summary": "A prototype meant to make labor lighter. Opens the Carnival gates and moves the forest boulder blocking Deep Mines access.",
       "tag": "Key Item",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 52, "y": 68, "region": "Carnival Quarter" }
     },
     {
       "id": "manifestos",
       "title": "Lost Manifestos (I-III)",
       "summary": "Forbidden texts that reveal the true liturgy hidden behind the Palace's gold trim and pretense. Truth that needs no sermon, only a vessel.",
       "tag": "Quest Item",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 64, "y": 24, "region": "Gilt Palace" }
     },
     {
       "id": "dreamroot",
       "title": "Dreamroot",
       "summary": "A rare plant that may restore the ability to dream. Sought by those who remember what sleeping used to mean.",
       "tag": "Rare Material",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 28, "y": 60, "region": "Verdant Hollows" }
     },
     {
       "id": "sparkling-mineral",
       "title": "Sparkling Mineral",
       "summary": "Hidden deep below, once dreamed of by the Taskmaster. Reminds builders how to construct with hope instead of mere order.",
       "tag": "Crafting Material",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 80, "y": 72, "region": "Deep Mines" }
     },
     {
       "id": "golden-cap",
       "title": "Golden Cap Sphere",
       "summary": "Alchemical creation that clears mind fog. Brewed from Honeyglobe Capsules and memories of clearer times.",
       "tag": "Consumable",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 45, "y": 48, "region": "Alchemists' Span" }
     },
     {
       "id": "blooming-robes",
       "title": "Blooming Robes",
       "summary": "Discarded Choir vestments where spores took root. They bloom beautifully, telling secrets in fungal rhythms.",
       "tag": "Trade Item",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 35, "y": 22, "region": "Choir Ruins" }
     },
     {
       "id": "lost-camera",
       "title": "Lost Camera",
       "summary": "Found in the mines, traded by the Gatherer. Helps the Sporeborn capture the beauty they see in darkness.",
       "tag": "Quest Item",
-      "category": "Item"
+      "category": "Item",
+      "location": { "x": 86, "y": 55, "region": "Subterranean Galleries" }
+    },
+    {
+      "id": "starwoven-compass",
+      "title": "Starwoven Compass",
+      "summary": "A lattice of meteor-thread that points toward the last place someone felt truly at peace. Revered by cloud-sailors.",
+      "tag": "Key Item",
+      "category": "Relic",
+      "location": { "x": 12, "y": 18, "region": "Skybreak Ridge" }
+    },
+    {
+      "id": "echo-lantern",
+      "title": "Echo Lantern",
+      "summary": "Lantern that remembers voices it hears and replays them as guiding harmonies within the dusk-tunnels.",
+      "tag": "Utility",
+      "category": "Item",
+      "location": { "x": 58, "y": 82, "region": "Dusk Tunnels" }
+    },
+    {
+      "id": "choral-seed",
+      "title": "Choral Seed Reliquary",
+      "summary": "A seed pod humming with dormant choir notes. Planting it awakens protective hymns around a campsite.",
+      "tag": "Defensive",
+      "category": "Artifact",
+      "location": { "x": 42, "y": 30, "region": "Resonant Plaza" }
+    },
+    {
+      "id": "tideturn-vial",
+      "title": "Tideturn Vial",
+      "summary": "Captures one ebb of the underground sea. When shattered, it reverses gravity for a heartbeat.",
+      "tag": "Consumable",
+      "category": "Alchemical",
+      "location": { "x": 76, "y": 40, "region": "Undersea Observatory" }
     }
   ]
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,17 @@
       <button id="export" title="Export current view as JSON">Export JSON</button>
       <span class="badge">Showing <span id="count">0/0</span></span>
     </div>
+    <section class="map-wrapper" aria-label="Interactive map of the Dreamless Kingdom">
+      <div class="map-header">
+        <h2>Atlas Overlay</h2>
+        <p class="small">Markers glow when they match your current search. Click a marker to open the full entry.</p>
+      </div>
+      <div id="map" class="map" role="img" aria-label="Stylised map of the Dreamless Kingdom with item markers"></div>
+      <div class="map-legend small">
+        <span class="legend-item"><span class="legend-dot"></span> Discoverable entry</span>
+        <span class="legend-item"><span class="legend-dot dim"></span> Outside current filters</span>
+      </div>
+    </section>
     <section id="grid" class="grid" aria-live="polite"></section>
     <div class="footer">v0.1 • Static app (no build) • Data: <code>data/entries.json</code></div>
   </div>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,17 @@
       <button id="export" title="Export current view as JSON">Export JSON</button>
       <span class="badge">Showing <span id="count">0/0</span></span>
     </div>
+    <section class="map-wrapper" aria-label="Interactive map of the Dreamless Kingdom">
+      <div class="map-header">
+        <h2>Atlas Overlay</h2>
+        <p class="small">Markers glow when they match your current search. Click a marker to open the full entry.</p>
+      </div>
+      <div id="map" class="map" role="img" aria-label="Stylised map of the Dreamless Kingdom with item markers"></div>
+      <div class="map-legend small">
+        <span class="legend-item"><span class="legend-dot"></span> Discoverable entry</span>
+        <span class="legend-item"><span class="legend-dot dim"></span> Outside current filters</span>
+      </div>
+    </section>
     <section id="grid" class="grid" aria-live="polite"></section>
     <div class="footer">v0.1 • Static app (no build) • Data: <code>data/entries.json</code></div>
   </div>


### PR DESCRIPTION
## Summary
- add an atlas overlay map with legend to the living encyclopedia layout
- render interactive markers that reflect filters and open entries from the map
- enrich the dataset with location metadata and four new discoveries

## Testing
- python -m json.tool data/entries.json
- python -m json.tool docs/data/entries.json

------
https://chatgpt.com/codex/tasks/task_e_68dc2bf1ea348322a2208699c6b24518