### PR TITLE
Add flora catalog and multi-tab browsing

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,18 +1,127 @@
+const worldName = 'Dreamless Kingdom';
 
-const state = {
-  entries: [],
-  filtered: [],
-  tags: new Set(),
-  q: '',
-  tag: 'All',
+const catalogs = {
+  entries: {
+    key: 'entries',
+    label: 'Encyclopedia',
+    tagLabel: 'Tag',
+    searchPlaceholder: 'Search titles and summaries… (press /)',
+    exportFile: 'dreamless-kingdom-entries.json',
+    datasetField: 'entries',
+    getTag: (item) => item.tag,
+    searchFields: [
+      (item) => item.title,
+      (item) => item.summary,
+      (item) => item.category,
+      (item) => item.tag
+    ],
+    modalTitle: 'Entry',
+    cardSummary: (item) => item.summary,
+    renderModal: (item, catalogKey) => {
+      const hooks = generateHooks(item);
+      return `
+        <div class="kv">
+          <div>World</div><div>${worldName}</div>
+          <div>Category</div><div>${item.category || 'Entry'}</div>
+          <div>Tag</div><div>${item.tag}</div>
+          <div>ID</div><div><code>${item.id}</code></div>
+        </div>
+        <hr/>
+        <p>${item.summary}</p>
+        <h3>Adventure Hooks</h3>
+        <ul>${hooks.map((h) => `<li>${h}</li>`).join('')}</ul>
+        <hr/>
+        <div class="small">Deep link: <a href="#/${catalogKey}/${item.id}">#/${catalogKey}/${item.id}</a></div>
+      `;
+    }
+  },
+  flora: {
+    key: 'flora',
+    label: 'Flora Atlas',
+    tagLabel: 'Ecosystem',
+    searchPlaceholder: 'Search plants by name, ecosystem, or traits…',
+    exportFile: 'dreamless-kingdom-flora.json',
+    datasetField: 'plants',
+    getTag: (item) => item.ecosystem,
+    searchFields: [
+      (item) => item.title,
+      (item) => item.summary,
+      (item) => item.ecosystem,
+      (item) => (item.features || []).join(' '),
+      (item) => (item.uses || []).join(' '),
+      (item) => item.hazards,
+      (item) => item.propagation
+    ],
+    modalTitle: 'Plant',
+    cardSummary: (item) => item.summary,
+    renderModal: (item, catalogKey) => {
+      const notes = generateFieldNotes(item);
+      const parts = [];
+      if (item.features && item.features.length) {
+        parts.push(`
+          <h3>Key Traits</h3>
+          <ul>${item.features.map((f) => `<li>${f}</li>`).join('')}</ul>
+        `);
+      }
+      if (item.uses && item.uses.length) {
+        parts.push(`
+          <h3>Common Uses</h3>
+          <ul>${item.uses.map((u) => `<li>${u}</li>`).join('')}</ul>
+        `);
+      }
+      if (item.hazards) {
+        parts.push(`
+          <h3>Risks & Precautions</h3>
+          <p>${item.hazards}</p>
+        `);
+      }
+      if (item.propagation) {
+        parts.push(`
+          <h3>Propagation Ritual</h3>
+          <p>${item.propagation}</p>
+        `);
+      }
+      parts.push(`
+        <h3>Field Notes</h3>
+        <ul>${notes.map((n) => `<li>${n}</li>`).join('')}</ul>
+      `);
+      return `
+        <div class="kv">
+          <div>World</div><div>${worldName}</div>
+          <div>Catalog</div><div>${catalogs.flora.label}</div>
+          <div>Ecosystem</div><div>${item.ecosystem}</div>
+          <div>Classification</div><div>${item.classification || 'Plant'}</div>
+          <div>Rarity</div><div>${item.rarity || 'Unknown'}</div>
+          <div>ID</div><div><code>${item.id}</code></div>
+        </div>
+        <hr/>
+        <p>${item.summary}</p>
+        ${parts.join('')}
+        <hr/>
+        <div class="small">Deep link: <a href="#/${catalogKey}/${item.id}">#/${catalogKey}/${item.id}</a></div>
+      `;
+    }
+  }
 };
 
-function normalize(s) { return (s||'').toLowerCase(); }
+const state = {
+  active: 'entries',
+  catalogs: {
+    entries: { list: [], filtered: [], tags: new Set(), tag: 'All', q: '' },
+    flora: { list: [], filtered: [], tags: new Set(), tag: 'All', q: '' }
+  }
+};
 
-function generateHooks(e) {
-  const hooks = [];
-  const t = e.title;
-  const tag = e.tag;
+function normalize(value) {
+  return (value || '').toString().toLowerCase();
+}
+
+function hashFromString(value) {
+  return Array.from(normalize(value)).reduce((acc, char) => acc + char.charCodeAt(0), 0);
+}
+
+function generateHooks(entry) {
+  const t = entry.title;
   const seeds = [
     `A caravan arrives seeking the ${t}. Their leader claims it belongs to their lineage. Decide who is right.`,
     `A child in the village has dreams of the ${t}. The dreams reveal a hidden location each night.`,
@@ -21,124 +130,267 @@ function generateHooks(e) {
     `A fissure opens in the Deep Mines, echoing the pulse of the ${t}. Explore before it seals.`,
     `A guild archivist insists the ${t} is counterfeit. Prove or disprove it in the field.`
   ];
-  // pick three deterministic by hash of id for stable hooks
-  const h = Array.from(normalize(e.id)).reduce((a,c)=>a+c.charCodeAt(0),0);
-  hooks.push(seeds[h % seeds.length]);
-  hooks.push(seeds[(h+2) % seeds.length]);
-  hooks.push(seeds[(h+4) % seeds.length]);
-  return hooks;
+  const base = hashFromString(entry.id);
+  return [
+    seeds[base % seeds.length],
+    seeds[(base + 2) % seeds.length],
+    seeds[(base + 4) % seeds.length]
+  ];
+}
+
+function generateFieldNotes(plant) {
+  const t = plant.title;
+  const e = plant.ecosystem;
+  const seeds = [
+    `Seasonal wardens report the ${t} shifting the balance in ${e}. Document who it aids and who it hinders.`,
+    `An apprentice botanist believes the ${t} can revive a failing refuge. Test their theory without angering local stewards.`,
+    `Trade envoys offer contraband in exchange for the ${t}. Decide whether its spread beyond ${e} is wise.`,
+    `The ${t} reacts strangely during this cycle's eclipse. Determine if it is a warning or an opportunity.`,
+    `A rival catalog insists the ${t} is myth. Gather proof before their dismissal erases crucial knowledge.`,
+    `Migratory beasts have begun nesting near the ${t}. Map the new symbiosis and its risks.`,
+    `The ${t} mirrors the Choir's latest hymn. Record what happens if the song is altered mid-verse.`
+  ];
+  const base = hashFromString(plant.id);
+  return [
+    seeds[base % seeds.length],
+    seeds[(base + 3) % seeds.length],
+    seeds[(base + 5) % seeds.length]
+  ];
+}
+
+function setActiveCatalog(key, opts = {}) {
+  if (!catalogs[key]) return;
+  const changed = state.active !== key;
+  state.active = key;
+  const config = catalogs[key];
+  const dataset = state.catalogs[key];
+  const searchInput = document.querySelector('#q');
+  if (searchInput) {
+    searchInput.placeholder = config.searchPlaceholder;
+    searchInput.value = dataset.q || '';
+  }
+  renderTabs();
+  renderTags();
+  applyFilters();
+  if (changed && !opts.silent) {
+    closeModal();
+  }
 }
 
 function applyFilters() {
-  const q = normalize(state.q);
-  const tag = state.tag;
-  state.filtered = state.entries.filter(e => {
-    const matchesQ = !q || normalize(e.title).includes(q) || normalize(e.summary).includes(q);
-    const matchesTag = tag === 'All' || e.tag === tag;
+  const key = state.active;
+  const config = catalogs[key];
+  const dataset = state.catalogs[key];
+  const q = normalize(dataset.q);
+  const tagSelection = dataset.tag;
+  dataset.filtered = dataset.list.filter((item) => {
+    const matchesQ = !q || config.searchFields.some((fn) => {
+      const value = fn(item);
+      return value && normalize(value).includes(q);
+    });
+    const tagValue = config.getTag(item);
+    const matchesTag = tagSelection === 'All' || tagValue === tagSelection;
     return matchesQ && matchesTag;
   });
   renderGrid();
   renderCount();
 }
 
-function renderCount(){
-  document.querySelector('#count').textContent = `${state.filtered.length} / ${state.entries.length}`;
+function renderCount() {
+  const dataset = state.catalogs[state.active];
+  const el = document.querySelector('#count');
+  if (el) {
+    el.textContent = `${dataset.filtered.length} / ${dataset.list.length}`;
+  }
 }
 
 function renderGrid() {
   const grid = document.querySelector('#grid');
+  if (!grid) return;
   grid.innerHTML = '';
+  const config = catalogs[state.active];
+  const dataset = state.catalogs[state.active];
+  if (!dataset.filtered.length) {
+    const empty = document.createElement('article');
+    empty.className = 'card';
+    empty.innerHTML = '<p class="small">No results match your filters yet. Adjust your search or ecosystem.</p>';
+    grid.appendChild(empty);
+    return;
+  }
   const frag = document.createDocumentFragment();
-  state.filtered.forEach(e=>{
+  dataset.filtered.forEach((item) => {
     const card = document.createElement('article');
     card.className = 'card';
-    card.innerHTML = `<h3>${e.title}</h3>
-      <p class="small">${e.summary}</p>
-      <span class="tag">${e.tag}</span>`;
-    card.addEventListener('click', ()=>openModal(e));
+    const tagValue = config.getTag(item);
+    const summary = config.cardSummary(item);
+    card.innerHTML = `
+      <h3>${item.title}</h3>
+      <p class="small">${summary}</p>
+      ${tagValue ? `<span class="tag">${tagValue}</span>` : ''}
+    `;
+    card.addEventListener('click', () => openModal(item, state.active));
     frag.appendChild(card);
   });
   grid.appendChild(frag);
 }
 
-function renderTags(){
+function renderTags() {
   const bar = document.querySelector('#tags');
+  if (!bar) return;
+  const config = catalogs[state.active];
+  const dataset = state.catalogs[state.active];
   bar.innerHTML = '';
+  const label = document.querySelector('#tag-label');
+  if (label) {
+    label.textContent = config.tagLabel;
+  }
   const all = document.createElement('button');
-  all.className = 'badge' + (state.tag==='All'?' active':'');
+  all.type = 'button';
+  all.className = 'badge' + (dataset.tag === 'All' ? ' active' : '');
   all.textContent = 'All';
-  all.addEventListener('click', ()=>{ state.tag = 'All'; applyFilters(); renderTags(); });
+  all.addEventListener('click', () => {
+    dataset.tag = 'All';
+    applyFilters();
+    renderTags();
+  });
   bar.appendChild(all);
-  Array.from(state.tags).sort().forEach(tag=>{
-    const b = document.createElement('button');
-    b.className = 'badge' + (state.tag===tag?' active':'');
-    b.textContent = tag;
-    b.addEventListener('click', ()=>{ state.tag = tag; applyFilters(); renderTags(); });
-    bar.appendChild(b);
+  Array.from(dataset.tags)
+    .filter(Boolean)
+    .sort()
+    .forEach((tag) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'badge' + (dataset.tag === tag ? ' active' : '');
+      btn.textContent = tag;
+      btn.addEventListener('click', () => {
+        dataset.tag = tag;
+        applyFilters();
+        renderTags();
+      });
+      bar.appendChild(btn);
+    });
+}
+
+function renderTabs() {
+  const tabs = document.querySelector('#catalog-tabs');
+  if (!tabs) return;
+  tabs.innerHTML = '';
+  Object.values(catalogs).forEach((config) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = state.active === config.key ? 'active' : '';
+    btn.setAttribute('role', 'tab');
+    btn.setAttribute('aria-selected', state.active === config.key ? 'true' : 'false');
+    btn.textContent = config.label;
+    btn.addEventListener('click', () => {
+      if (state.active !== config.key) {
+        setActiveCatalog(config.key);
+      }
+    });
+    tabs.appendChild(btn);
   });
 }
 
-function openModal(e){
+function openModal(item, catalogKey = state.active, opts = {}) {
   const modal = document.querySelector('#modal');
   const body = modal.querySelector('.body');
-  const hooks = generateHooks(e);
-  body.innerHTML = `
-    <div class="kv">
-      <div>World</div><div>Dreamless Kingdom</div>
-      <div>Category</div><div>${e.category||'Entry'}</div>
-      <div>Tag</div><div>${e.tag}</div>
-      <div>ID</div><div><code>${e.id}</code></div>
-    </div>
-    <hr/>
-    <p>${e.summary}</p>
-    <h3>Adventure Hooks</h3>
-    <ul>${hooks.map(h=>`<li>${h}</li>`).join('')}</ul>
-    <hr/>
-    <div class="small">Deep link: <a href="#/item/${e.id}">#/item/${e.id}</a></div>
-  `;
+  const heading = document.querySelector('#modal-heading');
+  const config = catalogs[catalogKey];
+  if (heading) {
+    heading.textContent = config.modalTitle;
+  }
+  body.innerHTML = config.renderModal(item, catalogKey);
   modal.classList.add('open');
-  location.hash = `#/item/${e.id}`;
+  if (!opts.fromHash) {
+    location.hash = `#/${catalogKey}/${item.id}`;
+  }
 }
 
-function closeModal(){
+function closeModal(opts = {}) {
   const modal = document.querySelector('#modal');
+  if (!modal.classList.contains('open')) return;
   modal.classList.remove('open');
-  if(location.hash.startsWith('#/item/')){
+  if (!opts.suppressHash) {
     history.pushState('', document.title, window.location.pathname + window.location.search);
   }
 }
 
-function restoreFromHash(){
-  const parts = location.hash.split('/');
-  if(parts.length===3 && parts[1]==='item'){
-    const id = parts[2];
-    const e = state.entries.find(e=>e.id===id);
-    if(e) openModal(e);
+function restoreFromHash() {
+  const hash = location.hash.replace(/^#/, '');
+  if (!hash) {
+    closeModal({ suppressHash: true });
+    return;
   }
+  const parts = hash.split('/').filter(Boolean);
+  if (parts.length !== 2) return;
+  let [catalogKey, id] = parts;
+  if (catalogKey === 'item') catalogKey = 'entries';
+  if (!catalogs[catalogKey]) return;
+  const dataset = state.catalogs[catalogKey];
+  const item = dataset.list.find((entry) => entry.id === id);
+  if (!item) return;
+  const tagValue = catalogs[catalogKey].getTag(item);
+  dataset.q = '';
+  dataset.tag = tagValue || 'All';
+  setActiveCatalog(catalogKey, { silent: true });
+  openModal(item, catalogKey, { fromHash: true });
 }
 
-async function main(){
-  const res = await fetch('data/entries.json');
-  const j = await res.json();
-  state.entries = j.entries;
-  state.tags = new Set(state.entries.map(e=>e.tag));
-  renderTags();
-  applyFilters();
+async function main() {
+  const [entriesRes, floraRes] = await Promise.all([
+    fetch('data/entries.json').then((r) => r.json()),
+    fetch('data/flora.json').then((r) => r.json())
+  ]);
+  state.catalogs.entries.list = entriesRes.entries || [];
+  state.catalogs.entries.tags = new Set(
+    (entriesRes.entries || []).map((entry) => catalogs.entries.getTag(entry)).filter(Boolean)
+  );
+  state.catalogs.flora.list = floraRes.plants || [];
+  state.catalogs.flora.tags = new Set(
+    (floraRes.plants || []).map((plant) => catalogs.flora.getTag(plant)).filter(Boolean)
+  );
+  setActiveCatalog(state.active, { silent: true });
   restoreFromHash();
 }
 
 window.addEventListener('hashchange', restoreFromHash);
-document.addEventListener('DOMContentLoaded', ()=>{
-  document.querySelector('#q').addEventListener('input', (e)=>{ state.q = e.target.value; applyFilters(); });
-  document.querySelector('#close').addEventListener('click', closeModal);
-  document.querySelector('#modal').addEventListener('click', (e)=>{ if(e.target.id==='modal') closeModal(); });
-  document.querySelector('#export').addEventListener('click', ()=>{
-    const blob = new Blob([JSON.stringify({world:'Dreamless Kingdom',entries:state.filtered}, null, 2)], {type:'application/json'});
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = 'dreamless-kingdom-entries.json';
-    a.click();
-    URL.revokeObjectURL(a.href);
-  });
+
+document.addEventListener('DOMContentLoaded', () => {
+  const searchInput = document.querySelector('#q');
+  if (searchInput) {
+    searchInput.addEventListener('input', (e) => {
+      const dataset = state.catalogs[state.active];
+      dataset.q = e.target.value;
+      applyFilters();
+    });
+  }
+  const closeBtn = document.querySelector('#close');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => closeModal());
+  }
+  const modal = document.querySelector('#modal');
+  if (modal) {
+    modal.addEventListener('click', (e) => {
+      if (e.target.id === 'modal') closeModal();
+    });
+  }
+  const exportBtn = document.querySelector('#export');
+  if (exportBtn) {
+    exportBtn.addEventListener('click', () => {
+      const config = catalogs[state.active];
+      const dataset = state.catalogs[state.active];
+      const payload = {
+        world: worldName,
+        catalog: config.label,
+        items: dataset.filtered
+      };
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = config.exportFile;
+      a.click();
+      URL.revokeObjectURL(a.href);
+    });
+  }
   main();
 });

--- a/assets/style.css
+++ b/assets/style.css
@@ -13,6 +13,12 @@ h1{font-weight:700;font-size:28px;margin:0 0 8px}
 input[type="search"]{flex:1;min-width:220px;background:var(--panel);border:1px solid var(--line);padding:10px 12px;border-radius:12px;color:var(--ink);outline:none}
 select,button{background:var(--panel);border:1px solid var(--line);padding:10px 12px;border-radius:12px;color:var(--ink);cursor:pointer}
 button:hover{border-color:var(--accent)}
+.tabs{display:flex;gap:8px;flex-wrap:wrap}
+.tabs button{border-radius:999px;padding:8px 14px;font-size:14px;border:1px solid var(--line);background:var(--panel);color:var(--muted)}
+.tabs button.active{border-color:var(--accent);color:var(--ink);background:rgba(224,177,65,0.12)}
+.tag-filter{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.tag-filter .label{font-size:12px;color:var(--muted)}
+.chipbar{display:flex;gap:8px;flex-wrap:wrap}
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:16px}
 .card{background:var(--panel);border:1px solid var(--line);padding:14px;border-radius:16px;transition:transform .1s ease, border-color .2s}
 .card:hover{transform:translateY(-2px);border-color:var(--accent)}

--- a/data/flora.json
+++ b/data/flora.json
@@ -1,0 +1,151 @@
+{
+  "catalog": "Flora Atlas",
+  "version": "0.1.0",
+  "generated_at": "2025-09-30T19:05:11.138316Z",
+  "plants": [
+    {
+      "id": "lumina-reed",
+      "title": "Lumina Reed",
+      "summary": "Slender stalks that store starlight and release it as a guided glow along waterways after dusk.",
+      "ecosystem": "Mist Marsh",
+      "classification": "Bioluminescent Reed",
+      "rarity": "Uncommon",
+      "features": [
+        "Roots inhale fog and exhale ribbons of cool vapor that settle along game trails.",
+        "Glows brighter in the presence of truthful speech, dimming when lies take hold."
+      ],
+      "uses": [
+        "Braided into lantern tatters to light pilgrim routes without open flame.",
+        "Steeped to brew a tonic that reveals hidden ink for a single night."
+      ],
+      "hazards": "Lures nocturnal predators when harvested in clusters; marsh guides stagger cuttings to stay unseen.",
+      "propagation": "Requires moonlit flooding for seedlings to take root; canalkeepers time sluices accordingly."
+    },
+    {
+      "id": "ember-thistle",
+      "title": "Ember Thistle",
+      "summary": "A stubborn briar whose barbs warm the soil, preventing frost kill in terraced farms clinging to the Scarred Rim.",
+      "ecosystem": "Scarred Rim Terraces",
+      "classification": "Thermogenic Thistle",
+      "rarity": "Rare",
+      "features": [
+        "Hums softly when storms approach, letting farmers cover seedlings in time.",
+        "Barbs ignite only after sunset, shedding gentle sparks over fallow rows."
+      ],
+      "uses": [
+        "Dried buds kindle low-smoke hearths for underground workshops.",
+        "Seed oil, mixed with slag dust, seals heat fractures in kilnworks."
+      ],
+      "hazards": "Improper pruning can trigger flash flares; apprentices train with water-veiled shears.",
+      "propagation": "Must be paired with basalt chips from retired watchtowers to keep the soil tempered."
+    },
+    {
+      "id": "chorus-moss",
+      "title": "Chorus Moss",
+      "summary": "Faintly sings in harmony with the Choir above, calming panic in Deep Mine tunnels when kept hydrated.",
+      "ecosystem": "Deep Mines",
+      "classification": "Resonant Bryophyte",
+      "rarity": "Common",
+      "features": [
+        "Changes pitch to mirror the emotional charge of nearby workers.",
+        "Absorbs metallic dust, keeping breathing tunnels clearer."
+      ],
+      "uses": [
+        "Woven into respirator linings for calming airflow.",
+        "Pressed between ledger pages to retain the tone of testimony."
+      ],
+      "hazards": "Dries into a brittle screech if removed from echoes for too long, shattering morale instead of soothing it.",
+      "propagation": "Fed with runoff from the Choir's condensation gutters once each cycle."
+    },
+    {
+      "id": "glassvine-orchid",
+      "title": "Glassvine Orchid",
+      "summary": "Translucent petals refract the skyline, disguising cliff nests in the Shardspire Reaches.",
+      "ecosystem": "Shardspire Reaches",
+      "classification": "Camouflaging Epiphyte",
+      "rarity": "Uncommon",
+      "features": [
+        "Tendrils memorize the light of each dawn, shifting hue to match it the next day.",
+        "Pods chime when winds exceed safe gliding speeds."
+      ],
+      "uses": [
+        "Hung over watchposts to hide rebel beacons from aerial patrols.",
+        "Distilled resin forms prisms used in signal encryption."
+      ],
+      "hazards": "Shatters into razor threads if handled with cold iron; harvesters wear heated silk gloves.",
+      "propagation": "Requires nesting partnerships with rookwing birds; stewards leave trinkets to invite them back."
+    },
+    {
+      "id": "emberleaf-tea",
+      "title": "Emberleaf Tea Tree",
+      "summary": "A compact tree whose leaves steep into a tea that keeps dreamless sleepers warm through the Palace nights.",
+      "ecosystem": "Palace Greenward",
+      "classification": "Aromatic Evergreen",
+      "rarity": "Cultivated",
+      "features": [
+        "Leaves carry faint lullabies remembered by the gardeners who prune them.",
+        "Bark inscribes annual rings shaped like closed eyes."
+      ],
+      "uses": [
+        "Brewed in the infirmary to steady the breath of exhausted scribes.",
+        "Powdered leaf dust polishes ceremonial masks without scratching gold filigree."
+      ],
+      "hazards": "Overharvesting steals the lullabies, leaving the tea bitter and unrestful.",
+      "propagation": "Cuttings root only when replanted beside a sleeping volunteer for three consecutive nights."
+    },
+    {
+      "id": "sunglint-cactus",
+      "title": "Sunglint Cactus",
+      "summary": "Stores enough dawnlight to irrigate a caravan's worth of succulents, releasing it as warm mist on command.",
+      "ecosystem": "Dawnward Expanse",
+      "classification": "Photosynthetic Reservoir",
+      "rarity": "Rare",
+      "features": [
+        "Spines align with constellations the caravan seeks, acting as living compasses.",
+        "Flesh ripens into panes that can be etched with travel maps."
+      ],
+      "uses": [
+        "Serves as emergency fog makers to hide nomad camps at sunrise.",
+        "Sap sweetens desalinators, allowing brine to be reclaimed twice as fast."
+      ],
+      "hazards": "If tapped during eclipse hours, the stored light collapses into glassy dust, ruining the plant.",
+      "propagation": "Seeds must be sung to with caravan route chants passed down unbroken."
+    },
+    {
+      "id": "echofern",
+      "title": "Echofern",
+      "summary": "Fronds repeat whispered messages hours later, making them indispensable for secret correspondence across the Voidbridge.",
+      "ecosystem": "Voidbridge Platform",
+      "classification": "Mnemonic Fern",
+      "rarity": "Uncommon",
+      "features": [
+        "Fronds change color to indicate how many phrases they are holding.",
+        "Only repeats messages when brushed clockwise by the original speaker."
+      ],
+      "uses": [
+        "Serves as delayed courier for resistance cells working under curfew.",
+        "Archivists press fronds into treaties to ensure promises are literally remembered."
+      ],
+      "hazards": "If overburdened with secrets, fronds curl inward and refuse to open for a full season.",
+      "propagation": "Spore packets must cross the Voidbridge at dawn to remain viable."
+    },
+    {
+      "id": "hushbloom",
+      "title": "Hushbloom",
+      "summary": "Petals absorb ambient noise, allowing negotiators to carve private pockets of silence during market hour.",
+      "ecosystem": "Midnight Bazaar",
+      "classification": "Acoustic Absorber",
+      "rarity": "Rare",
+      "features": [
+        "Opens fully only when conversations reach a polite cadence.",
+        "Stores captured sounds as shimmering dust shaken free at dawn."
+      ],
+      "uses": [
+        "Crushed petals line council hoods so whispered advice goes unheard by spies.",
+        "Dust released at sunrise powers soundless wards around sanctuary rooms."
+      ],
+      "hazards": "If startled by shouting, releases stored clamor in a single deafening burst.",
+      "propagation": "Requires alternating days of raucous music and absolute quiet to bloom."
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -10,21 +10,25 @@
 <body>
   <div class="container">
     <h1>Dreamless Kingdom – Living Encyclopedia</h1>
-    <div class="sub">Search, filter, and deep-link entries. Click any card to see auto‑generated adventure hooks.</div>
+    <div class="sub">Search, filter, and deep-link entries and flora. Click any card to explore prompts and field notes.</div>
     <div class="toolbar">
+      <div id="catalog-tabs" class="tabs" role="tablist" aria-label="Catalog selection"></div>
       <input id="q" type="search" placeholder="Search titles and summaries… (press /)" />
-      <div id="tags" class="toolbar"></div>
+      <div class="tag-filter">
+        <span id="tag-label" class="label">Tag</span>
+        <div id="tags" class="chipbar" role="group"></div>
+      </div>
       <button id="export" title="Export current view as JSON">Export JSON</button>
       <span class="badge">Showing <span id="count">0/0</span></span>
     </div>
     <section id="grid" class="grid" aria-live="polite"></section>
-    <div class="footer">v0.1 • Static app (no build) • Data: <code>data/entries.json</code></div>
+      <div class="footer">v0.1 • Static app (no build) • Data: <code>data/entries.json</code>, <code>data/flora.json</code></div>
   </div>
 
   <div id="modal" class="modal" role="dialog" aria-modal="true" aria-label="Entry detail">
     <article class="sheet">
       <header>
-        <strong>Entry</strong>
+        <strong id="modal-heading">Entry</strong>
         <div class="right">
           <span class="small">Press <kbd>Esc</kbd> to close</span>
           <button id="close" aria-label="Close">Close</button>


### PR DESCRIPTION
## Summary
- introduce a dedicated flora catalog with curated plant data across Dreamless Kingdom ecosystems
- add a tabbed interface so readers can switch between encyclopedia entries and flora details while reusing search and filters
- enhance the modal, filtering, and export logic to support catalog-specific prompts and metadata

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dc2cfd74a0832297111c3915a5d7ee