### PR TITLE
Refocus flora catalogue and stabilise map layout

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -32,12 +32,12 @@ function generateHooks(e) {
   const t = e.title;
   const tag = e.tag;
   const seeds = [
-    `A caravan arrives seeking the ${t}. Their leader claims it belongs to their lineage. Decide who is right.`,
-    `A child in the village has dreams of the ${t}. The dreams reveal a hidden location each night.`,
-    `A Sporeborne artist offers a masterpiece if you let them study the ${t} for one hour.`,
-    `Rumor says the ${t} can silence the Choir for a day. Someone wants you to try.`,
-    `A fissure opens in the Deep Mines, echoing the pulse of the ${t}. Explore before it seals.`,
-    `A guild archivist insists the ${t} is counterfeit. Prove or disprove it in the field.`
+    `A grove-tender begs you to transplant the ${t} before a frost wave rolls across the Verdant Hollows.`,
+    `The Gilt Conservatory offers a charter if you retrieve living samples of the ${t} without bruising a single frond.`,
+    `Spore choristers swear the ${t} hums at dusk. Record its melody before the Choir Ruins collapse again.`,
+    `A caravan of night brewers covets the ${t}, but a rival syndicate posted a bounty to burn it first. Choose a side.`,
+    `Atlas mapwrights insist the ${t} migrates along ley-lines. Track its drift with the overlay before the trail fades.`,
+    `A dreamless sleeper briefly murmured the name ${t}. Discover what vision the plant shared.`
   ];
   // pick three deterministic by hash of id for stable hooks
   const h = Array.from(normalize(e.id)).reduce((a,c)=>a+c.charCodeAt(0),0);

--- a/assets/style.css
+++ b/assets/style.css
@@ -25,16 +25,19 @@ button:hover{border-color:var(--accent)}
 .map-wrapper{margin:28px 0;background:linear-gradient(135deg,#10182b,#181f33);border:1px solid var(--line);border-radius:24px;padding:20px;box-shadow:0 14px 32px rgba(0,0,0,.25)}
 .map-header{display:flex;flex-direction:column;gap:4px;margin-bottom:16px}
 .map-header h2{margin:0;font-size:20px}
-.map{position:relative;width:100%;padding-top:62%;border:1px solid var(--line);border-radius:18px;background:radial-gradient(circle at 30% 20%, rgba(224,177,65,.25), transparent 45%), radial-gradient(circle at 70% 70%, rgba(111,203,255,.18), transparent 50%), linear-gradient(160deg,#0f1524,#12192a 40%,#10152b 100%);overflow:hidden}
+.map{position:relative;width:100%;aspect-ratio:16/10;max-height:520px;border:1px solid var(--line);border-radius:18px;background:radial-gradient(circle at 30% 20%, rgba(224,177,65,.25), transparent 45%), radial-gradient(circle at 70% 70%, rgba(111,203,255,.18), transparent 50%), linear-gradient(160deg,#0f1524,#12192a 40%,#10152b 100%);overflow:hidden}
 .map::after{content:'';position:absolute;inset:0;background-image:linear-gradient(0deg,rgba(255,255,255,.05) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.05) 1px,transparent 1px);background-size:14% 14%;opacity:.35;pointer-events:none}
-.marker{position:absolute;transform:translate(-50%,-50%);width:18px;height:18px;border-radius:50%;border:2px solid rgba(255,255,255,.8);background:var(--accent);box-shadow:0 0 0 0 rgba(224,177,65,.6);animation:pulse 3s infinite;cursor:pointer;display:grid;place-items:center}
+.marker{position:absolute;transform:translate(-50%,-50%);width:clamp(14px,1.8vw,22px);aspect-ratio:1;border-radius:50%;border:2px solid rgba(255,255,255,.8);background:var(--accent);box-shadow:0 0 0 0 rgba(224,177,65,.6);animation:pulse 3s infinite;cursor:pointer;display:grid;place-items:center}
 .marker:focus-visible{outline:2px solid #fff;outline-offset:2px}
-.marker span{position:absolute;width:6px;height:6px;border-radius:50%;background:#121622}
+.marker span{position:absolute;width:40%;height:40%;border-radius:50%;background:#121622}
 .marker.dim{background:rgba(147,152,172,.65);border-color:rgba(211,214,224,.4);box-shadow:none;animation:none}
 .map-legend{display:flex;gap:16px;flex-wrap:wrap;margin-top:14px;color:var(--muted)}
 .legend-item{display:inline-flex;align-items:center;gap:6px}
 .legend-dot{width:10px;height:10px;border-radius:50%;background:var(--accent);border:1px solid rgba(255,255,255,.8)}
 .legend-dot.dim{background:rgba(147,152,172,.65);border-color:rgba(211,214,224,.4)}
+@supports not (aspect-ratio:1/1){
+  .map{padding-top:62%;}
+}
 @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(224,177,65,.6)}70%{box-shadow:0 0 0 14px rgba(224,177,65,0)}100%{box-shadow:0 0 0 0 rgba(224,177,65,0)}}
 .modal{position:fixed;inset:0;display:none;background:rgba(0,0,0,.55);place-items:center;padding:16px}
 .modal.open{display:grid}

--- a/data/entries.json
+++ b/data/entries.json
@@ -1,103 +1,119 @@
 {
   "world": "Dreamless Kingdom",
-  "version": "0.1.0",
-  "generated_at": "2025-09-30T19:05:11.138316Z",
+  "version": "0.2.0",
+  "generated_at": "2025-10-01T12:34:56Z",
   "entries": [
-    {
-      "id": "perfumer-incense",
-      "title": "Perfumer's Incense",
-      "summary": "Attracts rare creatures and grants passage past the forest guardians. Crafted from mint, memory, and longing.",
-      "tag": "Key Item",
-      "category": "Item",
-      "location": { "x": 18, "y": 36, "region": "Whispering Arboretum" }
-    },
-    {
-      "id": "power-belt",
-      "title": "Power Belt",
-      "summary": "A prototype meant to make labor lighter. Opens the Carnival gates and moves the forest boulder blocking Deep Mines access.",
-      "tag": "Key Item",
-      "category": "Item",
-      "location": { "x": 52, "y": 68, "region": "Carnival Quarter" }
-    },
-    {
-      "id": "manifestos",
-      "title": "Lost Manifestos (I-III)",
-      "summary": "Forbidden texts that reveal the true liturgy hidden behind the Palace's gold trim and pretense. Truth that needs no sermon, only a vessel.",
-      "tag": "Quest Item",
-      "category": "Item",
-      "location": { "x": 64, "y": 24, "region": "Gilt Palace" }
-    },
     {
       "id": "dreamroot",
       "title": "Dreamroot",
-      "summary": "A rare plant that may restore the ability to dream. Sought by those who remember what sleeping used to mean.",
-      "tag": "Rare Material",
-      "category": "Item",
+      "summary": "A silver-veined tuber steeped in lullaby sap. Stewards brew it to restore wandering minds to dreaming sleep.",
+      "tag": "Restorative",
+      "category": "Plant",
       "location": { "x": 28, "y": 60, "region": "Verdant Hollows" }
     },
     {
-      "id": "sparkling-mineral",
-      "title": "Sparkling Mineral",
-      "summary": "Hidden deep below, once dreamed of by the Taskmaster. Reminds builders how to construct with hope instead of mere order.",
-      "tag": "Crafting Material",
-      "category": "Item",
-      "location": { "x": 80, "y": 72, "region": "Deep Mines" }
+      "id": "honeyglobe-capsule",
+      "title": "Honeyglobe Capsule",
+      "summary": "Translucent pods that ripen only by moonlight. Their nectar stabilises volatile tonics for the Guild apothecaries.",
+      "tag": "Alchemical",
+      "category": "Plant",
+      "location": { "x": 45, "y": 46, "region": "Alchemists' Span" }
     },
     {
-      "id": "golden-cap",
-      "title": "Golden Cap Sphere",
-      "summary": "Alchemical creation that clears mind fog. Brewed from Honeyglobe Capsules and memories of clearer times.",
-      "tag": "Consumable",
-      "category": "Item",
-      "location": { "x": 45, "y": 48, "region": "Alchemists' Span" }
+      "id": "chorus-spore-cluster",
+      "title": "Chorus Spore Cluster",
+      "summary": "Fungal blooms that echo hymn fragments from the sunken Choir. Harvesters wear masks to avoid singing along forever.",
+      "tag": "Fungal",
+      "category": "Plant",
+      "location": { "x": 34, "y": 22, "region": "Choir Ruins" }
     },
     {
-      "id": "blooming-robes",
-      "title": "Blooming Robes",
-      "summary": "Discarded Choir vestments where spores took root. They bloom beautifully, telling secrets in fungal rhythms.",
-      "tag": "Trade Item",
-      "category": "Item",
-      "location": { "x": 35, "y": 22, "region": "Choir Ruins" }
+      "id": "glassfern-scribes",
+      "title": "Glassfern Scribes",
+      "summary": "Fronds as clear as vellum that capture whispered secrets in refracted light. Archivists trade entire libraries for one spool.",
+      "tag": "Arcane",
+      "category": "Plant",
+      "location": { "x": 18, "y": 36, "region": "Whispering Arboretum" }
     },
     {
-      "id": "lost-camera",
-      "title": "Lost Camera",
-      "summary": "Found in the mines, traded by the Gatherer. Helps the Sporeborn capture the beauty they see in darkness.",
-      "tag": "Quest Item",
-      "category": "Item",
-      "location": { "x": 86, "y": 55, "region": "Subterranean Galleries" }
+      "id": "moonlace-bloom",
+      "title": "Moonlace Bloom",
+      "summary": "Latticed petals that unfurl only when palace bells fall silent. Their pollen renders gold illusions briefly transparent.",
+      "tag": "Illusory",
+      "category": "Plant",
+      "location": { "x": 64, "y": 24, "region": "Gilt Palace Conservatory" }
     },
     {
-      "id": "starwoven-compass",
-      "title": "Starwoven Compass",
-      "summary": "A lattice of meteor-thread that points toward the last place someone felt truly at peace. Revered by cloud-sailors.",
-      "tag": "Key Item",
-      "category": "Relic",
+      "id": "emberleaf-vines",
+      "title": "Emberleaf Vines",
+      "summary": "Slow-burning creepers woven through festival floats. When braided correctly they warm whole caravans without smoke.",
+      "tag": "Utility",
+      "category": "Plant",
+      "location": { "x": 52, "y": 68, "region": "Carnival Quarter Greenways" }
+    },
+    {
+      "id": "tidal-iris",
+      "title": "Tidal Iris",
+      "summary": "Bioluminescent petals that sway in rhythm with the underground sea. Sailors wear them to sense incoming reverse currents.",
+      "tag": "Navigation",
+      "category": "Plant",
+      "location": { "x": 76, "y": 40, "region": "Undersea Observatory" }
+    },
+    {
+      "id": "starlit-bramble",
+      "title": "Starlit Bramble",
+      "summary": "Thorny coils that drink meteor light and release it in gentle pulses. Sky shepherds knot them into lantern crowns.",
+      "tag": "Luminescent",
+      "category": "Plant",
       "location": { "x": 12, "y": 18, "region": "Skybreak Ridge" }
     },
     {
-      "id": "echo-lantern",
-      "title": "Echo Lantern",
-      "summary": "Lantern that remembers voices it hears and replays them as guiding harmonies within the dusk-tunnels.",
-      "tag": "Utility",
-      "category": "Item",
-      "location": { "x": 58, "y": 82, "region": "Dusk Tunnels" }
-    },
-    {
-      "id": "choral-seed",
-      "title": "Choral Seed Reliquary",
-      "summary": "A seed pod humming with dormant choir notes. Planting it awakens protective hymns around a campsite.",
-      "tag": "Defensive",
-      "category": "Artifact",
+      "id": "whisper-willow",
+      "title": "Whisper Willow",
+      "summary": "A slender tree whose leaves mimic the cadence of nearby voices. Diplomats consult it before tense negotiations.",
+      "tag": "Diplomatic",
+      "category": "Plant",
       "location": { "x": 42, "y": 30, "region": "Resonant Plaza" }
     },
     {
-      "id": "tideturn-vial",
-      "title": "Tideturn Vial",
-      "summary": "Captures one ebb of the underground sea. When shattered, it reverses gravity for a heartbeat.",
-      "tag": "Consumable",
-      "category": "Alchemical",
-      "location": { "x": 76, "y": 40, "region": "Undersea Observatory" }
+      "id": "gloomcap-mantle",
+      "title": "Gloomcap Mantle",
+      "summary": "Shelf fungi that weave themselves into cloaks, absorbing stray light. Miners wear them to walk unseen past patrols.",
+      "tag": "Stealth",
+      "category": "Plant",
+      "location": { "x": 80, "y": 72, "region": "Deep Mines" }
+    },
+    {
+      "id": "dawnmire-reed",
+      "title": "Dawnmire Reed",
+      "summary": "Hollow reeds that fill with dawn mist and chime softly when danger nears. Marsh guides plant them along safe crossings.",
+      "tag": "Protective",
+      "category": "Plant",
+      "location": { "x": 58, "y": 82, "region": "Dusk Tunnels Fen" }
+    },
+    {
+      "id": "auric-marrow",
+      "title": "Auric Marrow",
+      "summary": "Root clusters that distil stray wealth into nourishing broth. Street healers ration it to those who give more than they keep.",
+      "tag": "Sustenance",
+      "category": "Plant",
+      "location": { "x": 38, "y": 54, "region": "Sunken Promenade" }
+    },
+    {
+      "id": "zephyr-peony",
+      "title": "Zephyr Peony",
+      "summary": "Wind-fed petals that store the memory of every breeze. Airship navigators read them like logbooks before setting sail.",
+      "tag": "Cartography",
+      "category": "Plant",
+      "location": { "x": 24, "y": 14, "region": "Wind-Carved Steps" }
+    },
+    {
+      "id": "umbral-mistle",
+      "title": "Umbral Mistle",
+      "summary": "Shadow-drinking vines prized by theatre troupes to deepen stage illusions. Too much contact stains skin with twilight.",
+      "tag": "Theatrical",
+      "category": "Plant",
+      "location": { "x": 66, "y": 58, "region": "Veiled Colonnade" }
     }
   ]
 }

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -32,12 +32,12 @@ function generateHooks(e) {
   const t = e.title;
   const tag = e.tag;
   const seeds = [
-    `A caravan arrives seeking the ${t}. Their leader claims it belongs to their lineage. Decide who is right.`,
-    `A child in the village has dreams of the ${t}. The dreams reveal a hidden location each night.`,
-    `A Sporeborne artist offers a masterpiece if you let them study the ${t} for one hour.`,
-    `Rumor says the ${t} can silence the Choir for a day. Someone wants you to try.`,
-    `A fissure opens in the Deep Mines, echoing the pulse of the ${t}. Explore before it seals.`,
-    `A guild archivist insists the ${t} is counterfeit. Prove or disprove it in the field.`
+    `A grove-tender begs you to transplant the ${t} before a frost wave rolls across the Verdant Hollows.`,
+    `The Gilt Conservatory offers a charter if you retrieve living samples of the ${t} without bruising a single frond.`,
+    `Spore choristers swear the ${t} hums at dusk. Record its melody before the Choir Ruins collapse again.`,
+    `A caravan of night brewers covets the ${t}, but a rival syndicate posted a bounty to burn it first. Choose a side.`,
+    `Atlas mapwrights insist the ${t} migrates along ley-lines. Track its drift with the overlay before the trail fades.`,
+    `A dreamless sleeper briefly murmured the name ${t}. Discover what vision the plant shared.`
   ];
   // pick three deterministic by hash of id for stable hooks
   const h = Array.from(normalize(e.id)).reduce((a,c)=>a+c.charCodeAt(0),0);

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -25,16 +25,19 @@ button:hover{border-color:var(--accent)}
 .map-wrapper{margin:28px 0;background:linear-gradient(135deg,#10182b,#181f33);border:1px solid var(--line);border-radius:24px;padding:20px;box-shadow:0 14px 32px rgba(0,0,0,.25)}
 .map-header{display:flex;flex-direction:column;gap:4px;margin-bottom:16px}
 .map-header h2{margin:0;font-size:20px}
-.map{position:relative;width:100%;padding-top:62%;border:1px solid var(--line);border-radius:18px;background:radial-gradient(circle at 30% 20%, rgba(224,177,65,.25), transparent 45%), radial-gradient(circle at 70% 70%, rgba(111,203,255,.18), transparent 50%), linear-gradient(160deg,#0f1524,#12192a 40%,#10152b 100%);overflow:hidden}
+.map{position:relative;width:100%;aspect-ratio:16/10;max-height:520px;border:1px solid var(--line);border-radius:18px;background:radial-gradient(circle at 30% 20%, rgba(224,177,65,.25), transparent 45%), radial-gradient(circle at 70% 70%, rgba(111,203,255,.18), transparent 50%), linear-gradient(160deg,#0f1524,#12192a 40%,#10152b 100%);overflow:hidden}
 .map::after{content:'';position:absolute;inset:0;background-image:linear-gradient(0deg,rgba(255,255,255,.05) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.05) 1px,transparent 1px);background-size:14% 14%;opacity:.35;pointer-events:none}
-.marker{position:absolute;transform:translate(-50%,-50%);width:18px;height:18px;border-radius:50%;border:2px solid rgba(255,255,255,.8);background:var(--accent);box-shadow:0 0 0 0 rgba(224,177,65,.6);animation:pulse 3s infinite;cursor:pointer;display:grid;place-items:center}
+.marker{position:absolute;transform:translate(-50%,-50%);width:clamp(14px,1.8vw,22px);aspect-ratio:1;border-radius:50%;border:2px solid rgba(255,255,255,.8);background:var(--accent);box-shadow:0 0 0 0 rgba(224,177,65,.6);animation:pulse 3s infinite;cursor:pointer;display:grid;place-items:center}
 .marker:focus-visible{outline:2px solid #fff;outline-offset:2px}
-.marker span{position:absolute;width:6px;height:6px;border-radius:50%;background:#121622}
+.marker span{position:absolute;width:40%;height:40%;border-radius:50%;background:#121622}
 .marker.dim{background:rgba(147,152,172,.65);border-color:rgba(211,214,224,.4);box-shadow:none;animation:none}
 .map-legend{display:flex;gap:16px;flex-wrap:wrap;margin-top:14px;color:var(--muted)}
 .legend-item{display:inline-flex;align-items:center;gap:6px}
 .legend-dot{width:10px;height:10px;border-radius:50%;background:var(--accent);border:1px solid rgba(255,255,255,.8)}
 .legend-dot.dim{background:rgba(147,152,172,.65);border-color:rgba(211,214,224,.4)}
+@supports not (aspect-ratio:1/1){
+  .map{padding-top:62%;}
+}
 @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(224,177,65,.6)}70%{box-shadow:0 0 0 14px rgba(224,177,65,0)}100%{box-shadow:0 0 0 0 rgba(224,177,65,0)}}
 .modal{position:fixed;inset:0;display:none;background:rgba(0,0,0,.55);place-items:center;padding:16px}
 .modal.open{display:grid}

--- a/docs/data/entries.json
+++ b/docs/data/entries.json
@@ -1,103 +1,119 @@
 {
   "world": "Dreamless Kingdom",
-  "version": "0.1.0",
-  "generated_at": "2025-09-30T19:05:11.138316Z",
+  "version": "0.2.0",
+  "generated_at": "2025-10-01T12:34:56Z",
   "entries": [
-    {
-      "id": "perfumer-incense",
-      "title": "Perfumer's Incense",
-      "summary": "Attracts rare creatures and grants passage past the forest guardians. Crafted from mint, memory, and longing.",
-      "tag": "Key Item",
-      "category": "Item",
-      "location": { "x": 18, "y": 36, "region": "Whispering Arboretum" }
-    },
-    {
-      "id": "power-belt",
-      "title": "Power Belt",
-      "summary": "A prototype meant to make labor lighter. Opens the Carnival gates and moves the forest boulder blocking Deep Mines access.",
-      "tag": "Key Item",
-      "category": "Item",
-      "location": { "x": 52, "y": 68, "region": "Carnival Quarter" }
-    },
-    {
-      "id": "manifestos",
-      "title": "Lost Manifestos (I-III)",
-      "summary": "Forbidden texts that reveal the true liturgy hidden behind the Palace's gold trim and pretense. Truth that needs no sermon, only a vessel.",
-      "tag": "Quest Item",
-      "category": "Item",
-      "location": { "x": 64, "y": 24, "region": "Gilt Palace" }
-    },
     {
       "id": "dreamroot",
       "title": "Dreamroot",
-      "summary": "A rare plant that may restore the ability to dream. Sought by those who remember what sleeping used to mean.",
-      "tag": "Rare Material",
-      "category": "Item",
+      "summary": "A silver-veined tuber steeped in lullaby sap. Stewards brew it to restore wandering minds to dreaming sleep.",
+      "tag": "Restorative",
+      "category": "Plant",
       "location": { "x": 28, "y": 60, "region": "Verdant Hollows" }
     },
     {
-      "id": "sparkling-mineral",
-      "title": "Sparkling Mineral",
-      "summary": "Hidden deep below, once dreamed of by the Taskmaster. Reminds builders how to construct with hope instead of mere order.",
-      "tag": "Crafting Material",
-      "category": "Item",
-      "location": { "x": 80, "y": 72, "region": "Deep Mines" }
+      "id": "honeyglobe-capsule",
+      "title": "Honeyglobe Capsule",
+      "summary": "Translucent pods that ripen only by moonlight. Their nectar stabilises volatile tonics for the Guild apothecaries.",
+      "tag": "Alchemical",
+      "category": "Plant",
+      "location": { "x": 45, "y": 46, "region": "Alchemists' Span" }
     },
     {
-      "id": "golden-cap",
-      "title": "Golden Cap Sphere",
-      "summary": "Alchemical creation that clears mind fog. Brewed from Honeyglobe Capsules and memories of clearer times.",
-      "tag": "Consumable",
-      "category": "Item",
-      "location": { "x": 45, "y": 48, "region": "Alchemists' Span" }
+      "id": "chorus-spore-cluster",
+      "title": "Chorus Spore Cluster",
+      "summary": "Fungal blooms that echo hymn fragments from the sunken Choir. Harvesters wear masks to avoid singing along forever.",
+      "tag": "Fungal",
+      "category": "Plant",
+      "location": { "x": 34, "y": 22, "region": "Choir Ruins" }
     },
     {
-      "id": "blooming-robes",
-      "title": "Blooming Robes",
-      "summary": "Discarded Choir vestments where spores took root. They bloom beautifully, telling secrets in fungal rhythms.",
-      "tag": "Trade Item",
-      "category": "Item",
-      "location": { "x": 35, "y": 22, "region": "Choir Ruins" }
+      "id": "glassfern-scribes",
+      "title": "Glassfern Scribes",
+      "summary": "Fronds as clear as vellum that capture whispered secrets in refracted light. Archivists trade entire libraries for one spool.",
+      "tag": "Arcane",
+      "category": "Plant",
+      "location": { "x": 18, "y": 36, "region": "Whispering Arboretum" }
     },
     {
-      "id": "lost-camera",
-      "title": "Lost Camera",
-      "summary": "Found in the mines, traded by the Gatherer. Helps the Sporeborn capture the beauty they see in darkness.",
-      "tag": "Quest Item",
-      "category": "Item",
-      "location": { "x": 86, "y": 55, "region": "Subterranean Galleries" }
+      "id": "moonlace-bloom",
+      "title": "Moonlace Bloom",
+      "summary": "Latticed petals that unfurl only when palace bells fall silent. Their pollen renders gold illusions briefly transparent.",
+      "tag": "Illusory",
+      "category": "Plant",
+      "location": { "x": 64, "y": 24, "region": "Gilt Palace Conservatory" }
     },
     {
-      "id": "starwoven-compass",
-      "title": "Starwoven Compass",
-      "summary": "A lattice of meteor-thread that points toward the last place someone felt truly at peace. Revered by cloud-sailors.",
-      "tag": "Key Item",
-      "category": "Relic",
+      "id": "emberleaf-vines",
+      "title": "Emberleaf Vines",
+      "summary": "Slow-burning creepers woven through festival floats. When braided correctly they warm whole caravans without smoke.",
+      "tag": "Utility",
+      "category": "Plant",
+      "location": { "x": 52, "y": 68, "region": "Carnival Quarter Greenways" }
+    },
+    {
+      "id": "tidal-iris",
+      "title": "Tidal Iris",
+      "summary": "Bioluminescent petals that sway in rhythm with the underground sea. Sailors wear them to sense incoming reverse currents.",
+      "tag": "Navigation",
+      "category": "Plant",
+      "location": { "x": 76, "y": 40, "region": "Undersea Observatory" }
+    },
+    {
+      "id": "starlit-bramble",
+      "title": "Starlit Bramble",
+      "summary": "Thorny coils that drink meteor light and release it in gentle pulses. Sky shepherds knot them into lantern crowns.",
+      "tag": "Luminescent",
+      "category": "Plant",
       "location": { "x": 12, "y": 18, "region": "Skybreak Ridge" }
     },
     {
-      "id": "echo-lantern",
-      "title": "Echo Lantern",
-      "summary": "Lantern that remembers voices it hears and replays them as guiding harmonies within the dusk-tunnels.",
-      "tag": "Utility",
-      "category": "Item",
-      "location": { "x": 58, "y": 82, "region": "Dusk Tunnels" }
-    },
-    {
-      "id": "choral-seed",
-      "title": "Choral Seed Reliquary",
-      "summary": "A seed pod humming with dormant choir notes. Planting it awakens protective hymns around a campsite.",
-      "tag": "Defensive",
-      "category": "Artifact",
+      "id": "whisper-willow",
+      "title": "Whisper Willow",
+      "summary": "A slender tree whose leaves mimic the cadence of nearby voices. Diplomats consult it before tense negotiations.",
+      "tag": "Diplomatic",
+      "category": "Plant",
       "location": { "x": 42, "y": 30, "region": "Resonant Plaza" }
     },
     {
-      "id": "tideturn-vial",
-      "title": "Tideturn Vial",
-      "summary": "Captures one ebb of the underground sea. When shattered, it reverses gravity for a heartbeat.",
-      "tag": "Consumable",
-      "category": "Alchemical",
-      "location": { "x": 76, "y": 40, "region": "Undersea Observatory" }
+      "id": "gloomcap-mantle",
+      "title": "Gloomcap Mantle",
+      "summary": "Shelf fungi that weave themselves into cloaks, absorbing stray light. Miners wear them to walk unseen past patrols.",
+      "tag": "Stealth",
+      "category": "Plant",
+      "location": { "x": 80, "y": 72, "region": "Deep Mines" }
+    },
+    {
+      "id": "dawnmire-reed",
+      "title": "Dawnmire Reed",
+      "summary": "Hollow reeds that fill with dawn mist and chime softly when danger nears. Marsh guides plant them along safe crossings.",
+      "tag": "Protective",
+      "category": "Plant",
+      "location": { "x": 58, "y": 82, "region": "Dusk Tunnels Fen" }
+    },
+    {
+      "id": "auric-marrow",
+      "title": "Auric Marrow",
+      "summary": "Root clusters that distil stray wealth into nourishing broth. Street healers ration it to those who give more than they keep.",
+      "tag": "Sustenance",
+      "category": "Plant",
+      "location": { "x": 38, "y": 54, "region": "Sunken Promenade" }
+    },
+    {
+      "id": "zephyr-peony",
+      "title": "Zephyr Peony",
+      "summary": "Wind-fed petals that store the memory of every breeze. Airship navigators read them like logbooks before setting sail.",
+      "tag": "Cartography",
+      "category": "Plant",
+      "location": { "x": 24, "y": 14, "region": "Wind-Carved Steps" }
+    },
+    {
+      "id": "umbral-mistle",
+      "title": "Umbral Mistle",
+      "summary": "Shadow-drinking vines prized by theatre troupes to deepen stage illusions. Too much contact stains skin with twilight.",
+      "tag": "Theatrical",
+      "category": "Plant",
+      "location": { "x": 66, "y": 58, "region": "Veiled Colonnade" }
     }
   ]
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,33 +3,33 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>Dreamless Kingdom – Living Encyclopedia</title>
-  <meta name="description" content="A lightweight, static encyclopedia for the world of Dreamless Kingdom."/>
+  <title>Dreamless Kingdom – Flora Catalogue</title>
+  <meta name="description" content="A lightweight plant catalogue for the world of Dreamless Kingdom."/>
   <link rel="stylesheet" href="assets/style.css"/>
 </head>
 <body>
   <div class="container">
-    <h1>Dreamless Kingdom – Living Encyclopedia</h1>
-    <div class="sub">Search, filter, and deep-link entries. Click any card to see auto‑generated adventure hooks.</div>
+    <h1>Dreamless Kingdom – Flora Catalogue</h1>
+    <div class="sub">Search, filter, and deep-link botanical entries. Click any specimen card to reveal auto‑generated story hooks.</div>
     <div class="toolbar">
       <input id="q" type="search" placeholder="Search titles and summaries… (press /)" />
       <div id="tags" class="toolbar"></div>
       <button id="export" title="Export current view as JSON">Export JSON</button>
       <span class="badge">Showing <span id="count">0/0</span></span>
     </div>
-    <section class="map-wrapper" aria-label="Interactive map of the Dreamless Kingdom">
+    <section class="map-wrapper" aria-label="Interactive flora map of the Dreamless Kingdom">
       <div class="map-header">
-        <h2>Atlas Overlay</h2>
-        <p class="small">Markers glow when they match your current search. Click a marker to open the full entry.</p>
+        <h2>Flora Atlas Overlay</h2>
+        <p class="small">Markers glow when a specimen matches your current search. Click a marker to open the full entry.</p>
       </div>
-      <div id="map" class="map" role="img" aria-label="Stylised map of the Dreamless Kingdom with item markers"></div>
+      <div id="map" class="map" role="img" aria-label="Stylised map of the Dreamless Kingdom with flora markers"></div>
       <div class="map-legend small">
-        <span class="legend-item"><span class="legend-dot"></span> Discoverable entry</span>
+        <span class="legend-item"><span class="legend-dot"></span> Discoverable specimen</span>
         <span class="legend-item"><span class="legend-dot dim"></span> Outside current filters</span>
       </div>
     </section>
     <section id="grid" class="grid" aria-live="polite"></section>
-    <div class="footer">v0.1 • Static app (no build) • Data: <code>data/entries.json</code></div>
+    <div class="footer">v0.2 • Plant catalogue • Data: <code>data/entries.json</code></div>
   </div>
 
   <div id="modal" class="modal" role="dialog" aria-modal="true" aria-label="Entry detail">

--- a/index.html
+++ b/index.html
@@ -3,33 +3,33 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>Dreamless Kingdom – Living Encyclopedia</title>
-  <meta name="description" content="A lightweight, static encyclopedia for the world of Dreamless Kingdom."/>
+  <title>Dreamless Kingdom – Flora Catalogue</title>
+  <meta name="description" content="A lightweight plant catalogue for the world of Dreamless Kingdom."/>
   <link rel="stylesheet" href="assets/style.css"/>
 </head>
 <body>
   <div class="container">
-    <h1>Dreamless Kingdom – Living Encyclopedia</h1>
-    <div class="sub">Search, filter, and deep-link entries. Click any card to see auto‑generated adventure hooks.</div>
+    <h1>Dreamless Kingdom – Flora Catalogue</h1>
+    <div class="sub">Search, filter, and deep-link botanical entries. Click any specimen card to reveal auto‑generated story hooks.</div>
     <div class="toolbar">
       <input id="q" type="search" placeholder="Search titles and summaries… (press /)" />
       <div id="tags" class="toolbar"></div>
       <button id="export" title="Export current view as JSON">Export JSON</button>
       <span class="badge">Showing <span id="count">0/0</span></span>
     </div>
-    <section class="map-wrapper" aria-label="Interactive map of the Dreamless Kingdom">
+    <section class="map-wrapper" aria-label="Interactive flora map of the Dreamless Kingdom">
       <div class="map-header">
-        <h2>Atlas Overlay</h2>
-        <p class="small">Markers glow when they match your current search. Click a marker to open the full entry.</p>
+        <h2>Flora Atlas Overlay</h2>
+        <p class="small">Markers glow when a specimen matches your current search. Click a marker to open the full entry.</p>
       </div>
-      <div id="map" class="map" role="img" aria-label="Stylised map of the Dreamless Kingdom with item markers"></div>
+      <div id="map" class="map" role="img" aria-label="Stylised map of the Dreamless Kingdom with flora markers"></div>
       <div class="map-legend small">
-        <span class="legend-item"><span class="legend-dot"></span> Discoverable entry</span>
+        <span class="legend-item"><span class="legend-dot"></span> Discoverable specimen</span>
         <span class="legend-item"><span class="legend-dot dim"></span> Outside current filters</span>
       </div>
     </section>
     <section id="grid" class="grid" aria-live="polite"></section>
-    <div class="footer">v0.1 • Static app (no build) • Data: <code>data/entries.json</code></div>
+    <div class="footer">v0.2 • Plant catalogue • Data: <code>data/entries.json</code></div>
   </div>
 
   <div id="modal" class="modal" role="dialog" aria-modal="true" aria-label="Entry detail">


### PR DESCRIPTION
## Summary
- retheme the encyclopedia UI toward a Dreamless Kingdom flora catalogue and refresh copy
- replace the conflicted item data with botanical specimens that include map coordinates
- stabilise the interactive map with an aspect-ratio based layout and responsive markers

## Testing
- python -m json.tool data/entries.json
- python -m json.tool docs/data/entries.json

------
https://chatgpt.com/codex/tasks/task_e_68dc3046e4588322946a6780163db497