### PR TITLE
Add autonomous explorer and observer dashboard

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -5,6 +5,8 @@ const state = {
   tags: new Set(),
   q: '',
   tag: 'All',
+  explorer: null,
+  explorerFrame: null,
 };
 
 function renderMapMarkers(){
@@ -14,7 +16,11 @@ function renderMapMarkers(){
   const filteredIds = new Set(state.filtered.map(e=>e.id));
   state.entries.filter(e=>e.location).forEach(e=>{
     const marker = document.createElement('button');
-    marker.className = 'marker' + (filteredIds.has(e.id) ? '' : ' dim');
+    const classes = ['marker'];
+    if(!filteredIds.has(e.id)) classes.push('dim');
+    if(state.explorer?.collected?.has(e.id)) classes.push('collected');
+    if(state.explorer?.target?.entry?.id === e.id) classes.push('target');
+    marker.className = classes.join(' ');
     marker.style.left = `${e.location.x}%`;
     marker.style.top = `${e.location.y}%`;
     marker.setAttribute('aria-label', `${e.title} — ${e.location.region||'Unknown region'}`);
@@ -23,6 +29,9 @@ function renderMapMarkers(){
     marker.addEventListener('click', ()=>openModal(e));
     map.appendChild(marker);
   });
+  if(state.explorer){
+    renderExplorerElement();
+  }
 }
 
 function normalize(s) { return (s||'').toLowerCase(); }
@@ -70,10 +79,12 @@ function renderGrid() {
   const frag = document.createDocumentFragment();
   state.filtered.forEach(e=>{
     const card = document.createElement('article');
-    card.className = 'card';
+    const isCollected = !!state.explorer?.collected?.has(e.id);
+    card.className = 'card' + (isCollected ? ' collected' : '');
     card.innerHTML = `<h3>${e.title}</h3>
       <p class="small">${e.summary}</p>
-      <span class="tag">${e.tag}</span>`;
+      <span class="tag">${e.tag}</span>
+      ${isCollected ? '<div class="card-status">Catalogued by roaming surveyor</div>' : ''}`;
     card.addEventListener('click', ()=>openModal(e));
     frag.appendChild(card);
   });
@@ -149,6 +160,7 @@ async function main(){
   applyFilters();
   restoreFromHash();
   renderMapMarkers();
+  initExplorer();
 }
 
 window.addEventListener('hashchange', restoreFromHash);
@@ -166,3 +178,190 @@ document.addEventListener('DOMContentLoaded', ()=>{
   });
   main();
 });
+
+function ensureExplorerElement(){
+  if(!state.explorer) return null;
+  const map = document.querySelector('#map');
+  if(!map) return null;
+  let el = map.querySelector('.explorer');
+  if(!el){
+    el = document.createElement('div');
+    el.className = 'explorer';
+    el.setAttribute('aria-hidden', 'true');
+    map.appendChild(el);
+  } else if(el.parentElement !== map){
+    map.appendChild(el);
+  }
+  state.explorer.element = el;
+  return el;
+}
+
+function renderExplorerElement(){
+  if(!state.explorer) return;
+  const el = ensureExplorerElement();
+  if(!el) return;
+  el.style.left = `${state.explorer.x}%`;
+  el.style.top = `${state.explorer.y}%`;
+}
+
+function renderExplorerStatus(){
+  const el = document.querySelector('#explorer-status');
+  if(!el || !state.explorer) return;
+  const ex = state.explorer;
+  let text = 'Surveyor calibrating instruments…';
+  if(ex.phase === 'travel' && ex.target?.entry){
+    const region = ex.target.entry.location?.region || 'Unknown region';
+    text = `En route to ${ex.target.entry.title} (${region})`;
+  } else if(ex.phase === 'collecting'){
+    const remaining = Math.max(0, ex.pauseTimer || 0);
+    const suffix = remaining > 0 ? ` (${Math.ceil(remaining)}s)` : '';
+    text = `Cataloguing ${ex.lastCollectedTitle}${suffix}`;
+  } else if(ex.phase === 'idle'){
+    text = 'Surveyor selecting the next waypoint…';
+  }
+  el.textContent = text;
+}
+
+function renderExplorerCount(){
+  const el = document.querySelector('#explorer-count');
+  if(!el || !state.explorer) return;
+  el.textContent = state.explorer.totalCollected;
+}
+
+function renderExplorerLog(){
+  const list = document.querySelector('#explorer-log');
+  if(!list || !state.explorer) return;
+  list.innerHTML = '';
+  const frag = document.createDocumentFragment();
+  state.explorer.log.forEach(item=>{
+    const li = document.createElement('li');
+    const time = item.time.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'});
+    li.innerHTML = `<span class="log-time">${time}</span><span class="log-title">${item.title}</span>`;
+    frag.appendChild(li);
+  });
+  if(!state.explorer.log.length){
+    const li = document.createElement('li');
+    li.className = 'empty';
+    li.textContent = 'No samples catalogued yet. Keep observing!';
+    frag.appendChild(li);
+  }
+  list.appendChild(frag);
+}
+
+function renderExplorerUI(){
+  renderExplorerElement();
+  renderExplorerStatus();
+  renderExplorerCount();
+  renderExplorerLog();
+  renderMapMarkers();
+}
+
+function pickExplorerTarget(){
+  const ex = state.explorer;
+  if(!ex) return;
+  const candidates = state.entries.filter(e=>e.location);
+  if(!candidates.length){
+    ex.phase = 'idle';
+    ex.target = null;
+    renderExplorerStatus();
+    return;
+  }
+  const unvisited = candidates.filter(e=>!ex.collected.has(e.id));
+  const pool = unvisited.length ? unvisited : candidates;
+  const next = pool[Math.floor(Math.random()*pool.length)];
+  ex.target = { entry: next };
+  ex.phase = 'travel';
+  renderExplorerStatus();
+  renderMapMarkers();
+}
+
+function handleExplorerCollect(entry){
+  const ex = state.explorer;
+  if(!ex) return;
+  const isNew = !ex.collected.has(entry.id);
+  ex.collected.add(entry.id);
+  ex.totalCollected += 1;
+  ex.log.unshift({ id: entry.id, title: entry.title, time: new Date() });
+  ex.log = ex.log.slice(0, 8);
+  ex.pauseTimer = 2.2;
+  ex.pauseDuration = ex.pauseTimer;
+  ex.phase = 'collecting';
+  ex.lastCollectedTitle = entry.title;
+  ex.target = null;
+  renderExplorerUI();
+  if(isNew){
+    renderGrid();
+  }
+}
+
+function explorerStep(ts){
+  const ex = state.explorer;
+  if(!ex) return;
+  if(!ex.lastTick) ex.lastTick = ts;
+  const dt = Math.min((ts - ex.lastTick)/1000, 0.25);
+  ex.lastTick = ts;
+
+  if(ex.pauseTimer && ex.pauseTimer > 0){
+    ex.pauseTimer = Math.max(0, ex.pauseTimer - dt);
+    renderExplorerStatus();
+    if(ex.pauseTimer === 0){
+      ex.phase = 'idle';
+      renderExplorerStatus();
+      pickExplorerTarget();
+    }
+  } else {
+    if(!ex.target){
+      pickExplorerTarget();
+    }
+    const targetEntry = ex.target?.entry;
+    if(targetEntry?.location){
+      const tx = targetEntry.location.x;
+      const ty = targetEntry.location.y;
+      const dx = tx - ex.x;
+      const dy = ty - ex.y;
+      const dist = Math.hypot(dx, dy);
+      if(dist < 0.4){
+        ex.x = tx;
+        ex.y = ty;
+        handleExplorerCollect(targetEntry);
+      } else if(dist > 0){
+        const move = ex.speed * dt;
+        if(move >= dist){
+          ex.x = tx;
+          ex.y = ty;
+        } else {
+          ex.x += (dx / dist) * move;
+          ex.y += (dy / dist) * move;
+        }
+      }
+    }
+  }
+
+  renderExplorerElement();
+  state.explorerFrame = requestAnimationFrame(explorerStep);
+}
+
+function initExplorer(){
+  if(!state.entries.length) return;
+  if(state.explorerFrame){
+    cancelAnimationFrame(state.explorerFrame);
+    state.explorerFrame = null;
+  }
+  state.explorer = {
+    x: 50,
+    y: 50,
+    speed: 9,
+    collected: new Set(),
+    log: [],
+    totalCollected: 0,
+    phase: 'idle',
+    pauseTimer: 0,
+    pauseDuration: 0,
+    lastCollectedTitle: '',
+    element: null,
+    lastTick: null,
+  };
+  ensureExplorerElement();
+  renderExplorerUI();
+  state.explorerFrame = requestAnimationFrame(explorerStep);
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -31,6 +31,8 @@ button:hover{border-color:var(--accent)}
 .marker:focus-visible{outline:2px solid #fff;outline-offset:2px}
 .marker span{position:absolute;width:40%;height:40%;border-radius:50%;background:#121622}
 .marker.dim{background:rgba(147,152,172,.65);border-color:rgba(211,214,224,.4);box-shadow:none;animation:none}
+.marker.collected{border-color:rgba(255,255,255,.9);box-shadow:0 0 0 8px rgba(224,177,65,.15)}
+.marker.target{animation:pulse 1.4s infinite;box-shadow:0 0 0 0 rgba(255,99,132,.65);background:#ff6384;border-color:rgba(255,255,255,.95)}
 .map-legend{display:flex;gap:16px;flex-wrap:wrap;margin-top:14px;color:var(--muted)}
 .legend-item{display:inline-flex;align-items:center;gap:6px}
 .legend-dot{width:10px;height:10px;border-radius:50%;background:var(--accent);border:1px solid rgba(255,255,255,.8)}
@@ -39,6 +41,7 @@ button:hover{border-color:var(--accent)}
   .map{padding-top:62%;}
 }
 @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(224,177,65,.6)}70%{box-shadow:0 0 0 14px rgba(224,177,65,0)}100%{box-shadow:0 0 0 0 rgba(224,177,65,0)}}
+.explorer{position:absolute;transform:translate(-50%,-50%);width:clamp(14px,1.9vw,24px);aspect-ratio:1;border-radius:50%;background:#ff4d57;border:2px solid rgba(255,255,255,.85);box-shadow:0 0 18px rgba(255,77,87,.65);transition:left .2s linear, top .2s linear}
 .modal{position:fixed;inset:0;display:none;background:rgba(0,0,0,.55);place-items:center;padding:16px}
 .modal.open{display:grid}
 .sheet{max-width:760px;width:100%;background:var(--panel);border:1px solid var(--line);border-radius:20px;overflow:hidden}
@@ -50,3 +53,18 @@ hr{border:none;border-top:1px solid var(--line);margin:16px 0}
 kbd{background:#0f1320;border:1px solid var(--line);padding:2px 6px;border-radius:6px}
 header .right{display:flex;gap:8px;align-items:center}
 .small{font-size:12px;color:var(--muted)}
+.muted{color:var(--muted)}
+.observer-panel{margin:28px 0;background:linear-gradient(135deg,#10182b,#151c2f);border:1px solid var(--line);border-radius:24px;padding:20px;box-shadow:0 10px 24px rgba(0,0,0,.25);display:grid;gap:16px}
+.panel-header h2{margin:0;font-size:20px}
+.panel-header p{margin:0}
+.observer-body{display:flex;flex-direction:column;gap:16px}
+.observer-stats{display:flex;flex-direction:column;gap:6px}
+.observer-stats .tally{font-size:16px}
+.observer-log{margin:0;padding-left:0;list-style:none;display:grid;gap:8px;max-height:200px;overflow:auto;font-size:13px}
+.observer-log li{display:flex;gap:12px;align-items:center;background:rgba(10,14,24,.65);border:1px solid rgba(255,255,255,.05);padding:8px 12px;border-radius:12px}
+.observer-log li.empty{justify-content:center;color:var(--muted);font-style:italic}
+.observer-log .log-time{font-variant-numeric:tabular-nums;color:var(--muted);min-width:64px}
+.observer-log .log-title{flex:1}
+.card.collected{border-color:rgba(224,177,65,.6);box-shadow:0 0 0 1px rgba(224,177,65,.35)}
+.card-status{margin-top:10px;font-size:12px;color:var(--muted);display:inline-flex;align-items:center;gap:6px}
+.card-status::before{content:'\2714';color:#8ee887;font-size:12px}

--- a/index.html
+++ b/index.html
@@ -28,6 +28,19 @@
         <span class="legend-item"><span class="legend-dot dim"></span> Outside current filters</span>
       </div>
     </section>
+    <section class="observer-panel" aria-live="polite" aria-label="Automated expedition tracker">
+      <div class="panel-header">
+        <h2>Expedition Observer</h2>
+        <p class="small">A lone surveyor roams the Dreamless Kingdom, collecting flora samples for the archive. Watch their progress and browse the catalogue at your leisure.</p>
+      </div>
+      <div class="observer-body">
+        <div class="observer-stats">
+          <div class="tally">Samples secured: <strong id="explorer-count">0</strong></div>
+          <div id="explorer-status" class="small muted">Surveyor calibrating instruments…</div>
+        </div>
+        <ol id="explorer-log" class="observer-log" aria-label="Recent specimens catalogued"></ol>
+      </div>
+    </section>
     <section id="grid" class="grid" aria-live="polite"></section>
     <div class="footer">v0.2 • Plant catalogue • Data: <code>data/entries.json</code></div>
   </div>


### PR DESCRIPTION
## Summary
- add an automated explorer that roams the atlas, gathers samples, and keeps a running log
- highlight targeted and catalogued specimens across the map and entry cards for at-a-glance status
- introduce an expedition observer panel so viewers can follow the zero-player loop while browsing the archive

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc32d684f88322809f7f2e3fb8f099