### PR TITLE
Add Dreamless Kingdom zone overlays and catalogue entries

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -9,10 +9,105 @@ const state = {
   explorerFrame: null,
 };
 
+const MAP_ZONES = [
+  {
+    name: 'Aurora Marches',
+    description: 'Skybreak Ridge • Wind-Carved Steps',
+    x: 20,
+    y: 18,
+    width: 28,
+    height: 20,
+    regions: ['Skybreak Ridge', 'Wind-Carved Steps']
+  },
+  {
+    name: 'Choir Expanse',
+    description: 'Resonant Plaza • Choir Ruins • Alchemists\' Span',
+    x: 38,
+    y: 30,
+    width: 30,
+    height: 22,
+    regions: ['Resonant Plaza', 'Choir Ruins', "Alchemists' Span"]
+  },
+  {
+    name: 'Verdant Hollows',
+    description: 'Dreamroot Terraces & Whispering Groves',
+    x: 30,
+    y: 60,
+    width: 34,
+    height: 24,
+    regions: ['Verdant Hollows', 'Whispering Arboretum']
+  },
+  {
+    name: 'Carnival Ribbon',
+    description: 'Sunken Promenade • Carnival Greenways',
+    x: 46,
+    y: 72,
+    width: 28,
+    height: 22,
+    regions: ['Sunken Promenade', 'Carnival Quarter Greenways']
+  },
+  {
+    name: 'Radiant Courts',
+    description: 'Gilt Palace • Veiled Colonnade • Shatterlight Forge',
+    x: 62,
+    y: 40,
+    width: 32,
+    height: 26,
+    regions: ['Gilt Palace Conservatory', 'Veiled Colonnade', 'Shatterlight Forge']
+  },
+  {
+    name: 'Tideglass Reach',
+    description: 'Undersea Observatory • Tideglass Reaches',
+    x: 82,
+    y: 52,
+    width: 28,
+    height: 24,
+    regions: ['Undersea Observatory', 'Tideglass Reaches']
+  },
+  {
+    name: 'Veiled Deepways',
+    description: 'Deep Mines • Dusk Tunnels',
+    x: 72,
+    y: 72,
+    width: 30,
+    height: 26,
+    regions: ['Deep Mines', 'Dusk Tunnels Fen']
+  },
+  {
+    name: 'Western Fringe',
+    description: 'Wanderer\'s Causeway • Archive Warrens',
+    x: 22,
+    y: 78,
+    width: 30,
+    height: 24,
+    regions: ["Wanderer's Causeway", 'Archive Warrens']
+  }
+];
+
+function renderMapZones(map){
+  const activeRegions = new Set(
+    state.filtered
+      .map(e => e.location?.region)
+      .filter(Boolean)
+  );
+  MAP_ZONES.forEach(zone => {
+    const zoneEl = document.createElement('div');
+    const isActive = zone.regions.some(region => activeRegions.has(region));
+    zoneEl.className = 'map-zone' + (isActive ? ' active' : '');
+    zoneEl.style.left = `${zone.x}%`;
+    zoneEl.style.top = `${zone.y}%`;
+    zoneEl.style.width = `${zone.width}%`;
+    zoneEl.style.height = `${(zone.height || zone.width)}%`;
+    zoneEl.innerHTML = `<strong>${zone.name}</strong>${zone.description ? `<span>${zone.description}</span>` : ''}`;
+    map.appendChild(zoneEl);
+  });
+}
+
 function renderMapMarkers(){
   const map = document.querySelector('#map');
   if(!map) return;
   map.innerHTML = '';
+  renderMapZones(map);
   const filteredIds = new Set(state.filtered.map(e=>e.id));
   state.entries.filter(e=>e.location).forEach(e=>{
     const marker = document.createElement('button');

--- a/assets/style.css
+++ b/assets/style.css
@@ -349,10 +349,24 @@ button:hover, .badge:hover {
   border-radius: 20px;
   border: 1px solid rgba(124, 111, 167, 0.35);
   background:
-    radial-gradient(circle at 30% 20%, rgba(212, 175, 55, 0.2), transparent 55%),
-    radial-gradient(circle at 70% 70%, rgba(111, 203, 255, 0.2), transparent 58%),
-    linear-gradient(160deg, #0f1524, #12192a 45%, #10152b 100%);
+    radial-gradient(circle at 26% 18%, rgba(212, 175, 55, 0.22), transparent 60%),
+    radial-gradient(circle at 78% 74%, rgba(111, 203, 255, 0.22), transparent 62%),
+    radial-gradient(circle at 12% 82%, rgba(96, 154, 255, 0.16), transparent 66%),
+    linear-gradient(168deg, #0c1322, #11182a 40%, #0a1223 100%);
+  background-size: 140% 140%;
+  background-position: 50% 48%;
   overflow: hidden;
+}
+
+.map::before {
+  content: '';
+  position: absolute;
+  inset: -12%;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.12), transparent 68%);
+  opacity: 0.35;
+  filter: blur(18px);
+  pointer-events: none;
+  z-index: 0;
 }
 
 .map::after {
@@ -360,11 +374,65 @@ button:hover, .badge:hover {
   position: absolute;
   inset: 0;
   background-image:
-    linear-gradient(0deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
-  background-size: 14% 14%;
-  opacity: 0.35;
+    linear-gradient(0deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 10% 10%;
+  opacity: 0.32;
   pointer-events: none;
+  z-index: 0;
+}
+
+.map-zone {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: radial-gradient(ellipse at center, rgba(124, 111, 167, 0.22), rgba(124, 111, 167, 0.08) 60%, transparent 72%);
+  border: 1px solid rgba(124, 111, 167, 0.35);
+  box-shadow: 0 0 60px rgba(124, 111, 167, 0.18);
+  padding: clamp(14px, 2vw, 22px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-family: 'Inconsolata', monospace;
+  font-size: clamp(0.6rem, 1.2vw, 0.75rem);
+  color: var(--muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  pointer-events: none;
+  z-index: 1;
+  opacity: 0.55;
+  transition: opacity 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease, transform 0.35s ease;
+}
+
+.map-zone strong {
+  display: block;
+  font-family: 'Crimson Text', serif;
+  font-size: clamp(0.7rem, 1.5vw, 0.9rem);
+  letter-spacing: 0.08em;
+  color: var(--accent-gold);
+  text-transform: uppercase;
+  text-shadow: 0 0 14px rgba(212, 175, 55, 0.35);
+}
+
+.map-zone span {
+  display: block;
+  margin-top: 4px;
+  font-size: clamp(0.55rem, 1vw, 0.7rem);
+  letter-spacing: 0.05em;
+  text-transform: none;
+  color: rgba(220, 214, 245, 0.55);
+}
+
+.map-zone.active {
+  opacity: 0.92;
+  border-color: rgba(212, 175, 55, 0.55);
+  box-shadow: 0 0 80px rgba(212, 175, 55, 0.25);
+  transform: translate(-50%, -50%) scale(1.03);
+}
+
+.map-zone.active span {
+  color: rgba(212, 175, 55, 0.72);
 }
 
 .marker {
@@ -380,6 +448,7 @@ button:hover, .badge:hover {
   cursor: pointer;
   display: grid;
   place-items: center;
+  z-index: 2;
 }
 
 .marker span {

--- a/data/entries.json
+++ b/data/entries.json
@@ -114,6 +114,38 @@
       "tag": "Theatrical",
       "category": "Plant",
       "location": { "x": 66, "y": 58, "region": "Veiled Colonnade" }
+    },
+    {
+      "id": "wanderers-ember",
+      "title": "Wanderer's Ember",
+      "summary": "Coal-bright moss that only ignites when a traveler hums their departure song. Guides plant it along the Wanderer's Causeway to keep midnight caravans visible.",
+      "tag": "Wayfinding",
+      "category": "Plant",
+      "location": { "x": 14, "y": 70, "region": "Wanderer's Causeway" }
+    },
+    {
+      "id": "archive-lichen-scroll",
+      "title": "Archive Lichen Scroll",
+      "summary": "Filigree lichens that unfurl into script when brushed with lantern soot. Record keepers in the Archive Warrens braid them into living ledgers.",
+      "tag": "Historical",
+      "category": "Plant",
+      "location": { "x": 26, "y": 84, "region": "Archive Warrens" }
+    },
+    {
+      "id": "tidelight-caul",
+      "title": "Tidelight Caul",
+      "summary": "Ribboned kelp that stores moonlight in brine pockets. Tideglass wardens stretch it across arches to guide bathyspheres through pitch currents.",
+      "tag": "Aquatic",
+      "category": "Plant",
+      "location": { "x": 88, "y": 56, "region": "Tideglass Reaches" }
+    },
+    {
+      "id": "shatterlight-thistle",
+      "title": "Shatterlight Thistle",
+      "summary": "Prismatic spines that refract forge embers into calibrating beams. Artificers of the Shatterlight Forge use them to temper dreaming steel.",
+      "tag": "Artifice",
+      "category": "Plant",
+      "location": { "x": 58, "y": 18, "region": "Shatterlight Forge" }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- expand the atlas with named Dreamless Kingdom zones that highlight when matching specimens are filtered
- refresh the map styling to feel more zoomed out and readable with softer gradients and layered glows
- grow the specimen catalogue with four additional lore-rich entries tied to the new regions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc62934a4c8322b1aa2cb11d67b52b