### PR TITLE
Add daily flora variants and refine atlas display

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -342,6 +342,34 @@ button:hover, .badge:hover {
   font-family: 'Inconsolata', monospace;
 }
 
+.map-variant {
+  margin-top: 10px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(12, 17, 32, 0.82);
+  border: 1px solid rgba(124, 111, 167, 0.35);
+  color: rgba(232, 227, 211, 0.82);
+  font-family: 'Inconsolata', monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1.5;
+  box-shadow: inset 0 0 12px rgba(124, 111, 167, 0.25);
+}
+
+.map-variant strong {
+  color: var(--accent-gold);
+  letter-spacing: 0.12em;
+}
+
+.map-variant .note {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: rgba(232, 227, 211, 0.65);
+}
+
 .map {
   position: relative;
   width: 100%;
@@ -386,53 +414,100 @@ button:hover, .badge:hover {
   position: absolute;
   transform: translate(-50%, -50%);
   border-radius: 50%;
-  background: radial-gradient(ellipse at center, rgba(124, 111, 167, 0.22), rgba(124, 111, 167, 0.08) 60%, transparent 72%);
+  background: radial-gradient(ellipse at center, rgba(124, 111, 167, 0.26), rgba(124, 111, 167, 0.06) 60%, transparent 74%);
   border: 1px solid rgba(124, 111, 167, 0.35);
   box-shadow: 0 0 60px rgba(124, 111, 167, 0.18);
-  padding: clamp(14px, 2vw, 22px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  font-family: 'Inconsolata', monospace;
-  font-size: clamp(0.6rem, 1.2vw, 0.75rem);
-  color: var(--muted);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
   pointer-events: none;
   z-index: 1;
-  opacity: 0.55;
+  opacity: 0.45;
   transition: opacity 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease, transform 0.35s ease;
-}
-
-.map-zone strong {
-  display: block;
-  font-family: 'Crimson Text', serif;
-  font-size: clamp(0.7rem, 1.5vw, 0.9rem);
-  letter-spacing: 0.08em;
-  color: var(--accent-gold);
-  text-transform: uppercase;
-  text-shadow: 0 0 14px rgba(212, 175, 55, 0.35);
-}
-
-.map-zone span {
-  display: block;
-  margin-top: 4px;
-  font-size: clamp(0.55rem, 1vw, 0.7rem);
-  letter-spacing: 0.05em;
-  text-transform: none;
-  color: rgba(220, 214, 245, 0.55);
 }
 
 .map-zone.active {
   opacity: 0.92;
   border-color: rgba(212, 175, 55, 0.55);
   box-shadow: 0 0 80px rgba(212, 175, 55, 0.25);
-  transform: translate(-50%, -50%) scale(1.03);
+  transform: translate(-50%, -50%) scale(1.05);
 }
 
-.map-zone.active span {
-  color: rgba(212, 175, 55, 0.72);
+.map-zone.active .map-zone-label {
+  border-color: rgba(212, 175, 55, 0.65);
+  color: rgba(232, 227, 211, 0.92);
+  box-shadow: 0 18px 36px rgba(212, 175, 55, 0.25);
+}
+
+.map-zone.active .map-zone-label span {
+  color: rgba(212, 175, 55, 0.78);
+}
+
+.map-zone-label {
+  position: absolute;
+  background: rgba(12, 17, 32, 0.92);
+  backdrop-filter: blur(6px);
+  border-radius: 14px;
+  border: 1px solid rgba(212, 175, 55, 0.35);
+  padding: 10px 16px;
+  text-align: center;
+  font-family: 'Inconsolata', monospace;
+  font-size: clamp(0.6rem, 1.2vw, 0.78rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+  z-index: 4;
+  min-width: clamp(120px, 16vw, 220px);
+  pointer-events: none;
+}
+
+.map-zone-label strong {
+  display: block;
+  font-family: 'Crimson Text', serif;
+  font-size: clamp(0.72rem, 1.6vw, 1rem);
+  letter-spacing: 0.06em;
+  color: var(--accent-gold);
+  text-transform: uppercase;
+  text-shadow: 0 0 14px rgba(212, 175, 55, 0.35);
+}
+
+.map-zone-label span {
+  display: block;
+  margin-top: 4px;
+  font-size: clamp(0.55rem, 1vw, 0.72rem);
+  letter-spacing: 0.04em;
+  text-transform: none;
+  color: rgba(220, 214, 245, 0.58);
+}
+
+.map-zone.label-below .map-zone-label {
+  top: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.map-zone.label-above .map-zone-label {
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.map-zone.label-above .map-zone-label::after,
+.map-zone.label-below .map-zone-label::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 1px;
+  background: linear-gradient(180deg, rgba(212, 175, 55, 0.6), transparent);
+  height: 28px;
+}
+
+.map-zone.label-below .map-zone-label::after {
+  top: -28px;
+}
+
+.map-zone.label-above .map-zone-label::after {
+  bottom: -28px;
+  transform: translateX(-50%) rotate(180deg);
 }
 
 .marker {
@@ -600,13 +675,22 @@ button:hover, .badge:hover {
   flex: 1;
 }
 
+.observer-log .log-note {
+  font-family: 'Inconsolata', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  color: rgba(212, 175, 55, 0.78);
+  text-transform: uppercase;
+  margin-left: 12px;
+}
+
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 24px;
 }
 
-.card {
+.card { 
   background: rgba(18, 22, 43, 0.85);
   border: 1px solid rgba(124, 111, 167, 0.35);
   padding: 22px;
@@ -636,8 +720,16 @@ button:hover, .badge:hover {
   opacity: 1;
 }
 
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 12px;
+}
+
 .card h3 {
-  margin: 0 0 12px;
+  margin: 0;
   font-size: 1.4rem;
   color: var(--accent-gold);
 }
@@ -649,9 +741,60 @@ button:hover, .badge:hover {
   font-size: 1rem;
 }
 
+.rarity-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(212, 175, 55, 0.18);
+  border: 1px solid rgba(212, 175, 55, 0.45);
+  color: var(--accent-gold);
+  font-family: 'Inconsolata', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.rarity-badge::before {
+  content: '\2728';
+  font-size: 0.85rem;
+}
+
+.rarity-common {
+  background: rgba(47, 128, 237, 0.18);
+  border-color: rgba(111, 203, 255, 0.45);
+  color: #9cd4ff;
+}
+
+.rarity-rare {
+  background: rgba(124, 111, 167, 0.2);
+  border-color: rgba(124, 111, 167, 0.52);
+  color: #dcd4f5;
+}
+
+.rarity-mythic {
+  background: rgba(124, 111, 167, 0.22);
+  border-color: rgba(124, 111, 167, 0.55);
+  color: #e6d8ff;
+}
+
+.rarity-unstable {
+  background: rgba(255, 99, 132, 0.22);
+  border-color: rgba(255, 99, 132, 0.48);
+  color: #ff99a9;
+}
+
+.card-traits {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
 .card .tag {
   display: inline-block;
-  margin-top: 14px;
   padding: 6px 12px;
   border-radius: 999px;
   background: rgba(22, 33, 62, 0.95);
@@ -661,6 +804,18 @@ button:hover, .badge:hover {
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.08rem;
+}
+
+.card .tag.alt {
+  background: rgba(12, 17, 32, 0.85);
+  border-color: rgba(212, 175, 55, 0.55);
+  color: rgba(212, 175, 55, 0.85);
+}
+
+.card .tag.alt.subtle {
+  border-style: dashed;
+  color: rgba(232, 227, 211, 0.7);
+  border-color: rgba(232, 227, 211, 0.35);
 }
 
 .card.collected {
@@ -744,6 +899,29 @@ button:hover, .badge:hover {
   color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.08rem;
+}
+
+.variant-callout {
+  margin: 18px 0;
+  padding: 16px 20px;
+  border-radius: 16px;
+  background: rgba(12, 17, 32, 0.88);
+  border: 1px solid rgba(212, 175, 55, 0.4);
+  box-shadow: inset 0 0 24px rgba(212, 175, 55, 0.12);
+}
+
+.variant-callout h4 {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+  color: var(--accent-gold);
+  letter-spacing: 0.08rem;
+  text-transform: uppercase;
+  font-family: 'Inconsolata', monospace;
+}
+
+.variant-callout p {
+  margin: 0;
+  color: var(--ink);
 }
 
 hr {

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
             <div class="map-header">
               <h2>Flora Atlas Overlay</h2>
               <p>Markers glow when a specimen matches your current search. Click any marker to open the full entry.</p>
+              <div id="variant-cycle" class="map-variant" aria-live="polite"></div>
             </div>
             <div id="map" class="map" role="img" aria-label="Stylised map of the Dreamless Kingdom with flora markers"></div>
             <div class="map-legend small">


### PR DESCRIPTION
## Summary
- generate a daily flora cycle that enriches entries with rarity, mutation, and condition traits while updating cards, modals, and explorer logs to surface the details
- surface the current cycle in the atlas header and reposition map zone labels so they sit above markers instead of beneath them
- slow the roaming explorer and expand its status/log messaging so the cadence matches the more detailed variant updates

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc655114808322ac93b0fd570a5fc3