### PR TITLE
Add camera-following map and NPC interactions

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -379,7 +379,7 @@ button:hover, .badge:hover {
   background: radial-gradient(circle at 22% 18%, rgba(212, 175, 55, 0.18), transparent 62%),
               radial-gradient(circle at 82% 72%, rgba(117, 198, 255, 0.18), transparent 60%),
               linear-gradient(175deg, #0b1120 15%, #0f1628 55%, #080f1d 100%);
-  overflow: visible;
+  overflow: hidden;
   box-shadow: 0 26px 60px rgba(0, 0, 0, 0.55);
 }
 
@@ -405,6 +405,27 @@ button:hover, .badge:hover {
   pointer-events: none;
   z-index: 2;
   mix-blend-mode: screen;
+}
+
+.map-viewport {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.map-world {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: var(--map-world-size, 150%);
+  height: var(--map-world-size, 150%);
+  transform: translate3d(calc(-50% + var(--map-offset-x, 0px)), calc(-50% + var(--map-offset-y, 0px)), 0);
+  transition: transform 0.6s ease;
+  will-change: transform;
+}
+
+.map-world.no-transition {
+  transition: none !important;
 }
 
 .map-ground {
@@ -447,6 +468,15 @@ button:hover, .badge:hover {
 }
 
 .map-layer-markers .marker {
+  pointer-events: auto;
+}
+
+.map-layer-npcs {
+  z-index: 5;
+  pointer-events: none;
+}
+
+.map-layer-npcs .marker {
   pointer-events: auto;
 }
 
@@ -641,6 +671,11 @@ button:hover, .badge:hover {
   box-shadow: 0 0 0 0 rgba(255, 99, 132, 0.65);
 }
 
+.marker.npc.new-dialogue:not(.target) {
+  animation: pulse 1.8s infinite;
+  box-shadow: 0 0 0 0 rgba(99, 240, 255, 0.65);
+}
+
 .map-legend {
   display: flex;
   gap: 18px;
@@ -667,6 +702,12 @@ button:hover, .badge:hover {
 .legend-dot.character {
   background: linear-gradient(180deg, #63f0ff, #1f9bff);
   border-color: rgba(233, 248, 255, 0.9);
+}
+
+.legend-dot.npc-new {
+  background: linear-gradient(180deg, #aaf8ff, #63f0ff);
+  border-color: rgba(233, 248, 255, 0.95);
+  box-shadow: 0 0 10px rgba(99, 240, 255, 0.6);
 }
 
 .legend-dot.dim {
@@ -752,6 +793,18 @@ button:hover, .badge:hover {
   border-radius: 14px;
 }
 
+.observer-log li.dialogue {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  border-color: rgba(99, 240, 255, 0.2);
+}
+
+.observer-log li.dialogue.new {
+  border-color: rgba(212, 175, 55, 0.35);
+  box-shadow: 0 0 18px rgba(212, 175, 55, 0.15);
+}
+
 .observer-log li.empty {
   justify-content: center;
   color: var(--muted);
@@ -775,6 +828,37 @@ button:hover, .badge:hover {
   color: rgba(212, 175, 55, 0.78);
   text-transform: uppercase;
   margin-left: 12px;
+}
+
+.observer-log .log-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.observer-log .log-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+
+.observer-log .log-subtitle {
+  font-family: 'Inconsolata', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  color: rgba(124, 111, 167, 0.75);
+  text-transform: uppercase;
+}
+
+.observer-log .log-dialogue {
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: rgba(232, 227, 211, 0.86);
+}
+
+.observer-log .log-dialogue span {
+  display: block;
 }
 
 .grid {
@@ -992,6 +1076,66 @@ button:hover, .badge:hover {
   color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.08rem;
+}
+
+.npc-profile h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: var(--accent-gold);
+}
+
+.npc-profile p {
+  margin: 6px 0;
+}
+
+.npc-dialogue-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.npc-dialogue {
+  padding: 14px 18px;
+  border-radius: 16px;
+  border: 1px solid rgba(124, 111, 167, 0.35);
+  background: rgba(12, 17, 32, 0.8);
+  display: grid;
+  gap: 6px;
+}
+
+.npc-dialogue strong {
+  font-family: 'Inconsolata', monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(232, 227, 211, 0.85);
+}
+
+.npc-dialogue .preview {
+  color: rgba(232, 227, 211, 0.75);
+}
+
+.npc-dialogue .status {
+  font-family: 'Inconsolata', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(212, 175, 55, 0.7);
+}
+
+.npc-dialogue.locked {
+  border-style: dashed;
+  border-color: rgba(124, 111, 167, 0.35);
+  color: rgba(160, 154, 140, 0.65);
+}
+
+.npc-dialogue.locked .preview {
+  color: rgba(160, 154, 140, 0.7);
+}
+
+.npc-dialogue.locked .status {
+  color: rgba(160, 154, 140, 0.55);
 }
 
 .variant-callout {

--- a/index.html
+++ b/index.html
@@ -61,7 +61,8 @@
             <div id="map" class="map" role="img" aria-label="Stylised map of the Dreamless Kingdom with flora markers"></div>
             <div class="map-legend small">
               <span class="legend-item"><span class="legend-dot"></span> Discoverable specimen</span>
-              <span class="legend-item"><span class="legend-dot character"></span> Character entry</span>
+              <span class="legend-item"><span class="legend-dot character"></span> NPC contact</span>
+              <span class="legend-item"><span class="legend-dot npc-new"></span> NPC with new dialogue</span>
               <span class="legend-item"><span class="legend-dot dim"></span> Outside current filters</span>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- expand the atlas map plane and add a movable viewport that keeps the roaming surveyor centered while spreading locations apart
- introduce NPC contacts as alternate destinations with unlockable dialogue threads driven by the surveyor’s collected specimens
- refresh the expedition observer log, map legend, and modal styling to highlight NPC exchanges and their availability

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc6c861c788322b36ccb91827c6bac