### PR TITLE
Promote atlas view and expand map presentation

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -11,7 +11,7 @@ const state = {
   npcs: [],
 };
 
-const MAP_WORLD_SCALE = 1.26;
+const MAP_WORLD_SCALE = 1.12;
 
 const SCENE_EVENTS = [
   {

--- a/assets/style.css
+++ b/assets/style.css
@@ -312,14 +312,14 @@ button:hover, .badge:hover {
 
 .map-atlas {
   display: grid;
-  gap: 36px;
+  gap: 32px;
 }
 
 .map-panel {
   background: linear-gradient(135deg, rgba(26, 31, 52, 0.95), rgba(12, 18, 35, 0.95));
   border: 1px solid var(--accent-purple);
   border-radius: 26px;
-  padding: 24px 24px 28px;
+  padding: 20px 24px 26px;
   box-shadow: 0 22px 45px rgba(0, 0, 0, 0.45);
 }
 
@@ -340,20 +340,21 @@ button:hover, .badge:hover {
   margin: 0;
   color: var(--muted);
   font-family: 'Inconsolata', monospace;
+  max-width: 640px;
 }
 
 .map-variant {
-  margin-top: 16px;
-  padding: 16px 18px;
+  margin-top: 14px;
+  padding: 14px 16px;
   border-radius: 12px;
   background: rgba(12, 17, 32, 0.82);
   border: 1px solid rgba(124, 111, 167, 0.35);
   color: rgba(232, 227, 211, 0.82);
   font-family: 'Inconsolata', monospace;
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  line-height: 1.5;
+  line-height: 1.45;
   box-shadow: inset 0 0 12px rgba(124, 111, 167, 0.25);
 }
 
@@ -373,7 +374,7 @@ button:hover, .badge:hover {
 .map {
   position: relative;
   width: 100%;
-  max-width: 560px;
+  max-width: none;
   margin: 0 auto;
   aspect-ratio: 20/9;
   border-radius: 20px;
@@ -551,21 +552,21 @@ button:hover, .badge:hover {
 
 .map-zone-label {
   position: absolute;
-  --label-gap: 22px;
-  background: rgba(12, 17, 32, 0.92);
+  --label-gap: 18px;
+  background: rgba(12, 17, 32, 0.9);
   backdrop-filter: blur(6px);
   border-radius: 14px;
   border: 1px solid rgba(212, 175, 55, 0.35);
-  padding: 10px 16px;
+  padding: 8px 14px;
   text-align: center;
   font-family: 'Inconsolata', monospace;
-  font-size: clamp(0.6rem, 1.2vw, 0.78rem);
+  font-size: clamp(0.56rem, 1vw, 0.72rem);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--muted);
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.3);
   z-index: 8;
-  min-width: clamp(120px, 16vw, 220px);
+  min-width: clamp(110px, 14vw, 200px);
   pointer-events: none;
   transform: translate(calc(-50% + var(--label-shift-x, 0px)), var(--label-shift-y, 0px));
 }
@@ -573,17 +574,17 @@ button:hover, .badge:hover {
 .map-zone-label strong {
   display: block;
   font-family: 'Crimson Text', serif;
-  font-size: clamp(0.72rem, 1.6vw, 1rem);
+  font-size: clamp(0.68rem, 1.4vw, 0.95rem);
   letter-spacing: 0.06em;
   color: var(--accent-gold);
   text-transform: uppercase;
-  text-shadow: 0 0 14px rgba(212, 175, 55, 0.35);
+  text-shadow: 0 0 14px rgba(212, 175, 55, 0.3);
 }
 
 .map-zone-label span {
   display: block;
   margin-top: 4px;
-  font-size: clamp(0.55rem, 1vw, 0.72rem);
+  font-size: clamp(0.5rem, 0.95vw, 0.68rem);
   letter-spacing: 0.04em;
   text-transform: none;
   color: rgba(220, 214, 245, 0.58);
@@ -622,7 +623,7 @@ button:hover, .badge:hover {
 .marker {
   position: absolute;
   transform: translate(-50%, -50%);
-  width: clamp(10px, 1.25vw, 18px);
+  width: clamp(8px, 1vw, 14px);
   aspect-ratio: 1;
   border-radius: 50%;
   border: 2px solid rgba(255, 255, 255, 0.8);
@@ -680,9 +681,10 @@ button:hover, .badge:hover {
 
 .map-legend {
   display: flex;
-  gap: 22px;
+  gap: 18px;
   flex-wrap: wrap;
-  margin-top: 24px;
+  justify-content: center;
+  margin-top: 20px;
   font-family: 'Inconsolata', monospace;
   color: var(--muted);
 }
@@ -694,8 +696,8 @@ button:hover, .badge:hover {
 }
 
 .legend-dot {
-  width: 10px;
-  height: 10px;
+  width: 9px;
+  height: 9px;
   border-radius: 50%;
   background: var(--accent-gold);
   border: 1px solid rgba(255, 255, 255, 0.85);
@@ -715,6 +717,36 @@ button:hover, .badge:hover {
 .legend-dot.dim {
   background: rgba(124, 111, 167, 0.55);
   border-color: rgba(220, 214, 245, 0.45);
+}
+
+.overview-inline {
+  margin-top: 64px;
+  padding-top: 48px;
+  border-top: 1px solid rgba(124, 111, 167, 0.35);
+  display: grid;
+  gap: 36px;
+  scroll-margin-top: 120px;
+}
+
+.overview-inline h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  color: var(--accent-gold);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-shadow: 0 0 18px rgba(212, 175, 55, 0.32);
+}
+
+.overview-inline .section-intro {
+  max-width: 860px;
+}
+
+.overview-inline .timeline {
+  margin: 0;
+}
+
+.overview-inline .dialogue-box {
+  margin-top: 0;
 }
 
 @keyframes pulse {
@@ -1255,15 +1287,15 @@ header .right {
 
 @media (min-width: 960px) {
   .map-atlas {
-    grid-template-columns: 1.25fr 1.6fr;
+    grid-template-columns: minmax(0, 1.85fr) minmax(0, 1fr);
     align-items: start;
   }
 }
 
 @media (min-width: 1360px) {
   .map-atlas {
-    grid-template-columns: 1.1fr 1.4fr;
-    gap: 42px;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    gap: 48px;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -17,40 +17,13 @@
     </header>
 
     <nav class="nav-tabs" role="tablist" aria-label="Archive sections">
-      <button id="tab-overview" class="tab active" data-section="overview" type="button" role="tab" aria-selected="true">Overview</button>
-      <button id="tab-atlas" class="tab" data-section="atlas" type="button" role="tab" aria-selected="false">Atlas Overlay</button>
+      <button id="tab-atlas" class="tab active" data-section="atlas" type="button" role="tab" aria-selected="true">Atlas Overlay</button>
+      <button id="tab-overview" class="tab" data-section="overview" type="button" role="tab" aria-controls="overview" aria-selected="false">Archive Overview</button>
       <button id="tab-catalogue" class="tab" data-section="catalogue" type="button" role="tab" aria-selected="false">Specimen Catalogue</button>
     </nav>
 
     <main>
-      <section id="overview" class="content-section active" role="tabpanel" aria-labelledby="tab-overview">
-        <p class="section-intro">The flora of the Dreamless Kingdom remembers a time before the Palace rationed wonder. Spores weave memories between villages, and every bloom is a witness. This archive keeps their stories in motion while a lone surveyor charts the forgotten growth.</p>
-
-        <div class="timeline">
-          <article class="timeline-item">
-            <div class="timeline-date">Before the Silence</div>
-            <h3>Dream Gardens Flourish</h3>
-            <p>Collective gardens coaxed new species from shared reverie. These specimens shaped districts, guiding pilgrim paths by colour and scent.</p>
-          </article>
-          <article class="timeline-item">
-            <div class="timeline-date">The Extraction Age</div>
-            <h3>Palace Catalogues Desire</h3>
-            <p>Expeditions stripped the woods for proprietary spores. Villagers hid what they could, swearing botanists to secrecy as memory-taxation began.</p>
-          </article>
-          <article class="timeline-item">
-            <div class="timeline-date">Surveyor's Watch</div>
-            <h3>A Living Archive</h3>
-            <p>The lone observer now transcribes blooms in transit, syncing each discovery to this ledger. Your search reshapes where they wander next.</p>
-          </article>
-        </div>
-
-        <div class="dialogue-box">
-          <div class="dialogue-character">The Oracle</div>
-          <div class="dialogue-text">"I saw someone tend the spores instead of hoarding them. Help the surveyor keep the archive breathing and the Kingdom might remember how to dream again."</div>
-        </div>
-      </section>
-
-      <section id="atlas" class="content-section" role="tabpanel" aria-labelledby="tab-atlas">
+      <section id="atlas" class="content-section active" role="tabpanel" aria-labelledby="tab-atlas">
         <div class="map-atlas">
           <section class="map-panel" aria-label="Interactive flora map">
             <div class="map-header">
@@ -85,6 +58,34 @@
             </div>
           </section>
         </div>
+
+        <section id="overview" class="overview-inline" role="region" aria-labelledby="tab-overview">
+          <h2>Archive Overview</h2>
+          <p class="section-intro">The flora of the Dreamless Kingdom remembers a time before the Palace rationed wonder. Spores weave memories between villages, and every bloom is a witness. This archive keeps their stories in motion while a lone surveyor charts the forgotten growth.</p>
+
+          <div class="timeline">
+            <article class="timeline-item">
+              <div class="timeline-date">Before the Silence</div>
+              <h3>Dream Gardens Flourish</h3>
+              <p>Collective gardens coaxed new species from shared reverie. These specimens shaped districts, guiding pilgrim paths by colour and scent.</p>
+            </article>
+            <article class="timeline-item">
+              <div class="timeline-date">The Extraction Age</div>
+              <h3>Palace Catalogues Desire</h3>
+              <p>Expeditions stripped the woods for proprietary spores. Villagers hid what they could, swearing botanists to secrecy as memory-taxation began.</p>
+            </article>
+            <article class="timeline-item">
+              <div class="timeline-date">Surveyor's Watch</div>
+              <h3>A Living Archive</h3>
+              <p>The lone observer now transcribes blooms in transit, syncing each discovery to this ledger. Your search reshapes where they wander next.</p>
+            </article>
+          </div>
+
+          <div class="dialogue-box">
+            <div class="dialogue-character">The Oracle</div>
+            <div class="dialogue-text">"I saw someone tend the spores instead of hoarding them. Help the surveyor keep the archive breathing and the Kingdom might remember how to dream again."</div>
+          </div>
+        </section>
       </section>
 
       <section id="catalogue" class="content-section" role="tabpanel" aria-labelledby="tab-catalogue">
@@ -134,18 +135,30 @@
     (function(){
       const tabs = document.querySelectorAll('.nav-tabs .tab');
       const sections = document.querySelectorAll('.content-section');
+      const overviewSection = document.getElementById('overview');
 
-      function activateSection(id){
+      function activateSection(id, options = {}){
+        const isOverview = id === 'overview';
+        const effectiveId = isOverview ? 'atlas' : id;
+
         tabs.forEach((tab)=>{
           const match = tab.dataset.section === id;
           tab.classList.toggle('active', match);
           tab.setAttribute('aria-selected', String(match));
         });
+
         sections.forEach((section)=>{
-          section.classList.toggle('active', section.id === id);
+          section.classList.toggle('active', section.id === effectiveId);
         });
+
         if(!location.hash.startsWith('#/item/')){
-          history.replaceState(null, '', '#' + id);
+          const hashValue = isOverview ? '#overview' : `#${effectiveId}`;
+          history.replaceState(null, '', hashValue);
+        }
+
+        if(isOverview && overviewSection){
+          const behavior = options.instant ? 'auto' : 'smooth';
+          requestAnimationFrame(()=> overviewSection.scrollIntoView({ behavior, block: 'start' }));
         }
       }
 
@@ -162,7 +175,7 @@
       const hash = location.hash.replace('#','');
       if(hash && !hash.startsWith('/item/')){
         const target = document.getElementById(hash);
-        if(target){ activateSection(hash); }
+        if(target){ activateSection(hash, { instant: true }); }
       }
 
       const sporeContainer = document.getElementById('sporeContainer');


### PR DESCRIPTION
## Summary
- make the atlas tab the default landing experience and surface the lore overview beneath the map
- rebalance the map layout with wider columns, tighter UI chrome, and reduced marker sizing to show more of the world
- decrease the map world scale constant so the atlas starts further zoomed out

## Testing
- Manual QA: Loaded http://127.0.0.1:8000/index.html and exercised the atlas/overview navigation

------
https://chatgpt.com/codex/tasks/task_e_68dc796a14788322a1f9426e9c0817f7