### PR TITLE
Refine atlas zone detail presentation

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -559,13 +559,30 @@ button:hover, .badge:hover {
   transform: translate(-50%, -50%) scale(1.05);
 }
 
+.map-zone.selected {
+  opacity: 1;
+  border-color: rgba(212, 175, 55, 0.78);
+  box-shadow: 0 30px 62px rgba(212, 175, 55, 0.42);
+  transform: translate(-50%, -50%) scale(1.08);
+}
+
 .map-zone.active .map-zone-label {
   border-color: rgba(212, 175, 55, 0.65);
   color: rgba(232, 227, 211, 0.92);
   box-shadow: 0 18px 36px rgba(212, 175, 55, 0.25);
 }
 
+.map-zone.selected .map-zone-label {
+  border-color: rgba(212, 175, 55, 0.78);
+  color: rgba(245, 240, 228, 0.96);
+  box-shadow: 0 22px 44px rgba(212, 175, 55, 0.28);
+}
+
 .map-zone.active .map-zone-label span {
+  color: rgba(212, 175, 55, 0.78);
+}
+
+.map-zone.selected .map-zone-label span {
   color: rgba(212, 175, 55, 0.78);
 }
 
@@ -586,8 +603,24 @@ button:hover, .badge:hover {
   box-shadow: 0 14px 28px rgba(0, 0, 0, 0.28);
   z-index: 8;
   min-width: clamp(90px, 12vw, 180px);
-  pointer-events: none;
+  pointer-events: auto;
+  cursor: pointer;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
   transform: translate(calc(-50% + var(--label-shift-x, 0px)), var(--label-shift-y, 0px));
+}
+
+.map-zone-label:focus {
+  outline: none;
+}
+
+.map-zone-label:focus-visible {
+  outline: 2px solid rgba(212, 175, 55, 0.75);
+  outline-offset: 2px;
 }
 
 .map-zone-label strong {
@@ -639,13 +672,51 @@ button:hover, .badge:hover {
   transform: translateX(-50%) rotate(180deg);
 }
 
+.map-zone-detail {
+  position: absolute;
+  top: clamp(12px, 3vw, 24px);
+  right: clamp(12px, 3vw, 24px);
+  width: min(30%, 240px);
+  min-width: clamp(140px, 42vw, 220px);
+  background: rgba(12, 17, 32, 0.9);
+  border: 1px solid rgba(212, 175, 55, 0.32);
+  border-radius: 14px;
+  padding: clamp(10px, 2vw, 16px);
+  color: rgba(233, 229, 216, 0.95);
+  box-shadow: 0 24px 55px rgba(0, 0, 0, 0.45);
+  z-index: 12;
+  pointer-events: none;
+  display: grid;
+  gap: 6px;
+}
+
+.map-zone-detail[hidden] {
+  display: none;
+}
+
+.map-zone-detail h3 {
+  margin: 0;
+  font-family: 'Crimson Text', serif;
+  font-size: clamp(0.7rem, 1.2vw, 1rem);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent-gold);
+}
+
+.map-zone-detail p {
+  margin: 0;
+  font-size: clamp(0.6rem, 1vw, 0.82rem);
+  line-height: 1.4;
+  color: rgba(220, 214, 245, 0.86);
+}
+
 .marker {
   position: absolute;
   transform: translate(-50%, -50%);
-  width: clamp(6px, 0.7vw, 10px);
+  width: clamp(4px, 0.56vw, 8px);
   aspect-ratio: 1;
   border-radius: 50%;
-  border: 1.3px solid rgba(255, 255, 255, 0.82);
+  border: 1.1px solid rgba(255, 255, 255, 0.82);
   background: var(--accent-gold);
   box-shadow: 0 0 0 0 rgba(212, 175, 55, 0.6);
   animation: pulse 3s infinite;
@@ -657,8 +728,8 @@ button:hover, .badge:hover {
 
 .marker span {
   position: absolute;
-  width: 38%;
-  height: 38%;
+  width: 44%;
+  height: 44%;
   border-radius: 50%;
   background: rgba(18, 22, 43, 0.9);
 }
@@ -683,7 +754,7 @@ button:hover, .badge:hover {
 
 .marker.collected {
   border-color: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 0 0 6px rgba(212, 175, 55, 0.18);
+  box-shadow: 0 0 0 4px rgba(212, 175, 55, 0.18);
 }
 
 .marker.target {


### PR DESCRIPTION
## Summary
- shrink the atlas map markers for a subtler node appearance
- add a selectable zone detail panel that appears in the map's top-right corner
- improve zone accessibility with keyboard support and aria-expanded relationships

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd2737cb3c832284a8f9f5030c27e3