### PR TITLE
Shrink map UI elements

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -331,9 +331,9 @@ button:hover, .badge:hover {
 .map-panel {
   background: linear-gradient(135deg, rgba(26, 31, 52, 0.95), rgba(12, 18, 35, 0.95));
   border: 1px solid var(--accent-purple);
-  border-radius: 26px;
-  padding: 20px 24px 26px;
-  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.45);
+  border-radius: 22px;
+  padding: 16px 20px 22px;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
 }
 
 .observer-panel {
@@ -351,7 +351,7 @@ button:hover, .badge:hover {
 
 .map-header h2 {
   margin: 0;
-  font-size: 1.6rem;
+  font-size: 1.45rem;
   color: var(--accent-gold);
 }
 
@@ -359,22 +359,23 @@ button:hover, .badge:hover {
   margin: 0;
   color: var(--muted);
   font-family: 'Inconsolata', monospace;
-  max-width: 640px;
+  max-width: 580px;
+  font-size: 0.92rem;
 }
 
 .map-variant {
-  margin-top: 14px;
-  padding: 14px 16px;
-  border-radius: 12px;
+  margin-top: 12px;
+  padding: 12px 14px;
+  border-radius: 10px;
   background: rgba(12, 17, 32, 0.82);
   border: 1px solid rgba(124, 111, 167, 0.35);
   color: rgba(232, 227, 211, 0.82);
   font-family: 'Inconsolata', monospace;
-  font-size: 0.74rem;
+  font-size: 0.68rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  line-height: 1.45;
-  box-shadow: inset 0 0 12px rgba(124, 111, 167, 0.25);
+  line-height: 1.4;
+  box-shadow: inset 0 0 10px rgba(124, 111, 167, 0.25);
 }
 
 .map-variant strong {
@@ -385,7 +386,7 @@ button:hover, .badge:hover {
 .map-variant .note {
   display: block;
   margin-top: 4px;
-  font-size: 0.7rem;
+  font-size: 0.64rem;
   letter-spacing: 0.08em;
   color: rgba(232, 227, 211, 0.65);
 }
@@ -555,15 +556,15 @@ button:hover, .badge:hover {
 .map-zone.active {
   opacity: 0.95;
   border-color: rgba(212, 175, 55, 0.65);
-  box-shadow: 0 26px 55px rgba(212, 175, 55, 0.35);
-  transform: translate(-50%, -50%) scale(1.05);
+  box-shadow: 0 22px 48px rgba(212, 175, 55, 0.32);
+  transform: translate(-50%, -50%) scale(1.04);
 }
 
 .map-zone.selected {
   opacity: 1;
   border-color: rgba(212, 175, 55, 0.78);
-  box-shadow: 0 30px 62px rgba(212, 175, 55, 0.42);
-  transform: translate(-50%, -50%) scale(1.08);
+  box-shadow: 0 26px 54px rgba(212, 175, 55, 0.38);
+  transform: translate(-50%, -50%) scale(1.06);
 }
 
 .map-zone.active .map-zone-label {
@@ -593,21 +594,21 @@ button:hover, .badge:hover {
   backdrop-filter: blur(6px);
   border-radius: 12px;
   border: 1px solid rgba(212, 175, 55, 0.32);
-  padding: 6px 12px;
+  padding: 5px 10px;
   text-align: center;
   font-family: 'Inconsolata', monospace;
-  font-size: clamp(0.5rem, 0.9vw, 0.68rem);
+  font-size: clamp(0.46rem, 0.8vw, 0.62rem);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--muted);
   box-shadow: 0 14px 28px rgba(0, 0, 0, 0.28);
   z-index: 8;
-  min-width: clamp(90px, 12vw, 180px);
+  min-width: clamp(82px, 11vw, 160px);
   pointer-events: auto;
   cursor: pointer;
   display: inline-flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
   align-items: center;
   justify-content: center;
   text-decoration: none;
@@ -626,7 +627,7 @@ button:hover, .badge:hover {
 .map-zone-label strong {
   display: block;
   font-family: 'Crimson Text', serif;
-  font-size: clamp(0.62rem, 1.2vw, 0.88rem);
+  font-size: clamp(0.58rem, 1vw, 0.8rem);
   letter-spacing: 0.06em;
   color: var(--accent-gold);
   text-transform: uppercase;
@@ -636,7 +637,7 @@ button:hover, .badge:hover {
 .map-zone-label span {
   display: block;
   margin-top: 2px;
-  font-size: clamp(0.46rem, 0.8vw, 0.6rem);
+  font-size: clamp(0.42rem, 0.7vw, 0.55rem);
   letter-spacing: 0.04em;
   text-transform: none;
   color: rgba(220, 214, 245, 0.6);
@@ -676,18 +677,18 @@ button:hover, .badge:hover {
   position: absolute;
   top: clamp(12px, 3vw, 24px);
   right: clamp(12px, 3vw, 24px);
-  width: min(30%, 240px);
-  min-width: clamp(140px, 42vw, 220px);
+  width: min(28%, 220px);
+  min-width: clamp(132px, 38vw, 200px);
   background: rgba(12, 17, 32, 0.9);
   border: 1px solid rgba(212, 175, 55, 0.32);
-  border-radius: 14px;
-  padding: clamp(10px, 2vw, 16px);
+  border-radius: 12px;
+  padding: clamp(9px, 1.8vw, 14px);
   color: rgba(233, 229, 216, 0.95);
   box-shadow: 0 24px 55px rgba(0, 0, 0, 0.45);
   z-index: 12;
   pointer-events: none;
   display: grid;
-  gap: 6px;
+  gap: 5px;
 }
 
 .map-zone-detail[hidden] {
@@ -697,7 +698,7 @@ button:hover, .badge:hover {
 .map-zone-detail h3 {
   margin: 0;
   font-family: 'Crimson Text', serif;
-  font-size: clamp(0.7rem, 1.2vw, 1rem);
+  font-size: clamp(0.64rem, 1.1vw, 0.92rem);
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--accent-gold);
@@ -705,7 +706,7 @@ button:hover, .badge:hover {
 
 .map-zone-detail p {
   margin: 0;
-  font-size: clamp(0.6rem, 1vw, 0.82rem);
+  font-size: clamp(0.56rem, 0.9vw, 0.76rem);
   line-height: 1.4;
   color: rgba(220, 214, 245, 0.86);
 }
@@ -713,10 +714,10 @@ button:hover, .badge:hover {
 .marker {
   position: absolute;
   transform: translate(-50%, -50%);
-  width: clamp(4px, 0.56vw, 8px);
+  width: clamp(3px, 0.48vw, 7px);
   aspect-ratio: 1;
   border-radius: 50%;
-  border: 1.1px solid rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.82);
   background: var(--accent-gold);
   box-shadow: 0 0 0 0 rgba(212, 175, 55, 0.6);
   animation: pulse 3s infinite;
@@ -728,8 +729,8 @@ button:hover, .badge:hover {
 
 .marker span {
   position: absolute;
-  width: 44%;
-  height: 44%;
+  width: 42%;
+  height: 42%;
   border-radius: 50%;
   background: rgba(18, 22, 43, 0.9);
 }
@@ -771,10 +772,10 @@ button:hover, .badge:hover {
 
 .map-legend {
   display: flex;
-  gap: 18px;
+  gap: 14px;
   flex-wrap: wrap;
   justify-content: center;
-  margin-top: 20px;
+  margin-top: 16px;
   font-family: 'Inconsolata', monospace;
   color: var(--muted);
 }
@@ -782,12 +783,12 @@ button:hover, .badge:hover {
 .legend-item {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 5px;
 }
 
 .legend-dot {
-  width: 7px;
-  height: 7px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: var(--accent-gold);
   border: 1px solid rgba(255, 255, 255, 0.85);
@@ -848,7 +849,7 @@ button:hover, .badge:hover {
 .explorer {
   position: absolute;
   transform: translate(-50%, -50%);
-  width: clamp(9px, 1.1vw, 16px);
+  width: clamp(8px, 1vw, 14px);
   aspect-ratio: 1;
   border-radius: 50%;
   background: #ff4d57;


### PR DESCRIPTION
## Summary
- tighten map panel padding and typography to reduce the visual footprint of overlay controls
- scale down map zone labels, detail cards, and markers for a lighter map presentation
- shrink legend chips and explorer marker to keep supporting UI consistent with the smaller map styling

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd2a25c508832290dcc5fce2df58a6