### PR TITLE
Refine atlas layout and add NPC compendium

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -311,20 +311,17 @@ button:hover, .badge:hover {
   letter-spacing: 0.05rem;
 }
 
+
 .map-atlas {
   --map-edge: clamp(20px, 6vw, 120px);
   display: grid;
   gap: 32px;
-  grid-template-areas:
-    "map"
-    "observer";
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);
   padding-inline: var(--map-edge);
 }
 
 .map-panel {
-  grid-area: map;
   margin-inline: calc(-1 * var(--map-edge));
 }
 
@@ -336,10 +333,15 @@ button:hover, .badge:hover {
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
 }
 
+.atlas-overview-grid {
+  display: grid;
+  gap: 32px;
+}
+
 .observer-panel {
-  grid-area: observer;
   justify-self: stretch;
-  width: min(100%, 520px);
+  width: 100%;
+  max-width: 520px;
 }
 
 .map-header {
@@ -811,11 +813,15 @@ button:hover, .badge:hover {
 }
 
 .overview-inline {
-  margin-top: 64px;
-  padding-top: 48px;
-  border-top: 1px solid rgba(124, 111, 167, 0.35);
+  margin: 0;
+  padding: 32px;
+  border-top: none;
+  border-radius: 26px;
+  border: 1px solid rgba(124, 111, 167, 0.4);
+  background: linear-gradient(135deg, rgba(26, 31, 52, 0.96), rgba(12, 17, 34, 0.92));
+  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.45);
   display: grid;
-  gap: 36px;
+  gap: 32px;
   scroll-margin-top: 120px;
 }
 
@@ -838,6 +844,172 @@ button:hover, .badge:hover {
 
 .overview-inline .dialogue-box {
   margin-top: 0;
+}
+
+.section-header {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  color: var(--accent-gold);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-shadow: 0 0 18px rgba(212, 175, 55, 0.32);
+}
+
+.section-header .section-intro {
+  margin: 0;
+  max-width: 820px;
+}
+
+.npc-directory {
+  display: grid;
+  gap: 24px;
+}
+
+.npc-directory .empty-state {
+  padding: 26px;
+  border-radius: 22px;
+  border: 1px dashed rgba(124, 111, 167, 0.35);
+  background: rgba(12, 17, 32, 0.78);
+  color: var(--muted);
+  text-align: center;
+  font-family: 'Inconsolata', monospace;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.npc-card {
+  position: relative;
+  background: linear-gradient(135deg, rgba(18, 22, 43, 0.95), rgba(10, 15, 28, 0.92));
+  border: 1px solid rgba(124, 111, 167, 0.38);
+  border-radius: 24px;
+  padding: 26px;
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.45);
+  display: grid;
+  gap: 18px;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  text-align: left;
+}
+
+.npc-card:hover,
+.npc-card:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(212, 175, 55, 0.6);
+  box-shadow: 0 26px 46px rgba(212, 175, 55, 0.18);
+  outline: none;
+}
+
+.npc-card:focus-visible {
+  box-shadow: 0 0 0 3px rgba(212, 175, 55, 0.35), 0 26px 46px rgba(212, 175, 55, 0.18);
+}
+
+.npc-card.npc-card-new {
+  border-color: rgba(212, 175, 55, 0.55);
+  box-shadow: 0 0 28px rgba(212, 175, 55, 0.22);
+}
+
+.npc-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.npc-card h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: var(--ink);
+  letter-spacing: 0.08em;
+}
+
+.npc-card .npc-title {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-family: 'Inconsolata', monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+}
+
+.npc-card-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(212, 175, 55, 0.55);
+  background: rgba(212, 175, 55, 0.16);
+  color: rgba(212, 175, 55, 0.95);
+  font-family: 'Inconsolata', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.npc-card.npc-card-new .npc-card-status {
+  background: rgba(212, 175, 55, 0.28);
+}
+
+.npc-description {
+  margin: 0;
+  color: rgba(232, 227, 211, 0.78);
+  line-height: 1.6;
+}
+
+.npc-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-family: 'Inconsolata', monospace;
+  letter-spacing: 0.06em;
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.npc-meta .npc-region {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(124, 111, 167, 0.4);
+  background: rgba(12, 17, 32, 0.65);
+}
+
+.npc-meta .npc-location {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(124, 111, 167, 0.25);
+  background: rgba(26, 31, 52, 0.55);
+}
+
+.npc-dialogue-list.compact {
+  gap: 10px;
+}
+
+.npc-dialogue-list.compact .npc-dialogue {
+  padding: 12px 16px;
+  gap: 4px;
+}
+
+.npc-dialogue-list.compact .npc-dialogue .preview {
+  font-size: 0.9rem;
+}
+
+.npc-dialogue-list.compact .npc-dialogue .status {
+  font-size: 0.66rem;
+}
+
+.npc-dialogue.new {
+  border-color: rgba(212, 175, 55, 0.45);
+  box-shadow: 0 0 18px rgba(212, 175, 55, 0.18);
+}
+
+.npc-dialogue.new .status {
+  color: rgba(212, 175, 55, 0.85);
 }
 
 @keyframes pulse {
@@ -1385,9 +1557,13 @@ header .right {
     border-radius: 30px;
   }
 
+  .atlas-overview-grid {
+    grid-template-columns: minmax(320px, 520px) minmax(0, 1fr);
+    align-items: start;
+  }
+
   .observer-panel {
-    justify-self: end;
-    margin-right: calc(var(--map-edge) - var(--container-padding, 24px));
+    max-width: none;
   }
 }
 
@@ -1398,6 +1574,17 @@ header .right {
 
   .map-panel {
     border-radius: 34px;
+  }
+
+  .atlas-overview-grid {
+    grid-template-columns: minmax(360px, 560px) minmax(0, 1fr);
+    gap: 40px;
+  }
+}
+
+@media (min-width: 720px) {
+  .npc-directory {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
       <button id="tab-atlas" class="tab active" data-section="atlas" type="button" role="tab" aria-selected="true">Atlas Overlay</button>
       <button id="tab-overview" class="tab" data-section="overview" type="button" role="tab" aria-controls="overview" aria-selected="false">Archive Overview</button>
       <button id="tab-catalogue" class="tab" data-section="catalogue" type="button" role="tab" aria-selected="false">Specimen Catalogue</button>
+      <button id="tab-npcs" class="tab" data-section="npcs" type="button" role="tab" aria-controls="npcs" aria-selected="false">NPC Compendium</button>
     </nav>
 
     <main>
@@ -39,66 +40,74 @@
               <span class="legend-item"><span class="legend-dot dim"></span> Outside current filters</span>
             </div>
           </section>
+          <div class="atlas-overview-grid">
+            <section class="observer-panel" aria-live="polite" aria-label="Automated expedition tracker">
+              <div class="panel-header">
+                <h2>Expedition Observer</h2>
+                <p>A lone surveyor roams the Dreamless Kingdom, collecting flora samples for the archive. Watch their progress and browse the catalogue at your leisure.</p>
+              </div>
+              <div class="observer-body">
+                <div class="observer-stats">
+                  <div class="tally">Samples secured: <strong id="explorer-count">0</strong></div>
+                  <div id="explorer-status" class="small muted">Surveyor calibrating instruments…</div>
+                </div>
+                <div class="observer-scene" aria-live="polite">
+                  <div class="scene-label">Field conditions</div>
+                  <div id="observer-scene" class="scene-status muted">No anomalies detected.</div>
+                </div>
+                <ol id="explorer-log" class="observer-log" aria-label="Recent specimens catalogued"></ol>
+              </div>
+            </section>
 
-          <section class="observer-panel" aria-live="polite" aria-label="Automated expedition tracker">
-            <div class="panel-header">
-              <h2>Expedition Observer</h2>
-              <p>A lone surveyor roams the Dreamless Kingdom, collecting flora samples for the archive. Watch their progress and browse the catalogue at your leisure.</p>
-            </div>
-            <div class="observer-body">
-              <div class="observer-stats">
-                <div class="tally">Samples secured: <strong id="explorer-count">0</strong></div>
-                <div id="explorer-status" class="small muted">Surveyor calibrating instruments…</div>
+            <section id="overview" class="overview-inline" role="region" aria-labelledby="tab-overview">
+              <h2>Archive Overview</h2>
+              <p class="section-intro">The flora of the Dreamless Kingdom remembers a time before the Palace rationed wonder. Spores weave memories between villages, and every bloom is a witness. This archive keeps their stories in motion while a lone surveyor charts the forgotten growth.</p>
+
+              <div class="timeline">
+                <article class="timeline-item">
+                  <div class="timeline-date">Before the Silence</div>
+                  <h3>Dream Gardens Flourish</h3>
+                  <p>Collective gardens coaxed new species from shared reverie. These specimens shaped districts, guiding pilgrim paths by colour and scent.</p>
+                </article>
+                <article class="timeline-item">
+                  <div class="timeline-date">The Extraction Age</div>
+                  <h3>Palace Catalogues Desire</h3>
+                  <p>Expeditions stripped the woods for proprietary spores. Villagers hid what they could, swearing botanists to secrecy as memory-taxation began.</p>
+                </article>
+                <article class="timeline-item">
+                  <div class="timeline-date">Surveyor's Watch</div>
+                  <h3>A Living Archive</h3>
+                  <p>The lone observer now transcribes blooms in transit, syncing each discovery to this ledger. Your search reshapes where they wander next.</p>
+                </article>
               </div>
-              <div class="observer-scene" aria-live="polite">
-                <div class="scene-label">Field conditions</div>
-                <div id="observer-scene" class="scene-status muted">No anomalies detected.</div>
+
+              <div class="dialogue-box">
+                <div class="dialogue-character">The Oracle</div>
+                <div class="dialogue-text">"I saw someone tend the spores instead of hoarding them. Help the surveyor keep the archive breathing and the Kingdom might remember how to dream again."</div>
               </div>
-              <ol id="explorer-log" class="observer-log" aria-label="Recent specimens catalogued"></ol>
-            </div>
-          </section>
+            </section>
+          </div>
         </div>
-
-        <section id="overview" class="overview-inline" role="region" aria-labelledby="tab-overview">
-          <h2>Archive Overview</h2>
-          <p class="section-intro">The flora of the Dreamless Kingdom remembers a time before the Palace rationed wonder. Spores weave memories between villages, and every bloom is a witness. This archive keeps their stories in motion while a lone surveyor charts the forgotten growth.</p>
-
-          <div class="timeline">
-            <article class="timeline-item">
-              <div class="timeline-date">Before the Silence</div>
-              <h3>Dream Gardens Flourish</h3>
-              <p>Collective gardens coaxed new species from shared reverie. These specimens shaped districts, guiding pilgrim paths by colour and scent.</p>
-            </article>
-            <article class="timeline-item">
-              <div class="timeline-date">The Extraction Age</div>
-              <h3>Palace Catalogues Desire</h3>
-              <p>Expeditions stripped the woods for proprietary spores. Villagers hid what they could, swearing botanists to secrecy as memory-taxation began.</p>
-            </article>
-            <article class="timeline-item">
-              <div class="timeline-date">Surveyor's Watch</div>
-              <h3>A Living Archive</h3>
-              <p>The lone observer now transcribes blooms in transit, syncing each discovery to this ledger. Your search reshapes where they wander next.</p>
-            </article>
-          </div>
-
-          <div class="dialogue-box">
-            <div class="dialogue-character">The Oracle</div>
-            <div class="dialogue-text">"I saw someone tend the spores instead of hoarding them. Help the surveyor keep the archive breathing and the Kingdom might remember how to dream again."</div>
-          </div>
-        </section>
       </section>
 
       <section id="catalogue" class="content-section" role="tabpanel" aria-labelledby="tab-catalogue">
         <div class="catalogue-toolbar">
           <div class="controls">
             <input id="q" type="search" placeholder="Search titles and summaries… (press /)" />
-            <button id="export" title="Export current view as JSON">Export JSON</button>
           </div>
           <div class="controls" id="tags" role="group" aria-label="Filter by tag"></div>
           <div class="stats">Showing <span id="count">0/0</span></div>
         </div>
 
         <section id="grid" class="grid" aria-live="polite"></section>
+      </section>
+
+      <section id="npcs" class="content-section" role="tabpanel" aria-labelledby="tab-npcs">
+        <header class="section-header">
+          <h2>NPC Network</h2>
+          <p class="section-intro">Meet the Dreamless Kingdom's trusted contacts. Status updates as the expedition unlocks new exchanges.</p>
+        </header>
+        <div id="npc-directory" class="npc-directory" aria-live="polite"></div>
       </section>
     </main>
 


### PR DESCRIPTION
## Summary
- add an NPC Compendium tab that lists each contact, highlights new exchanges, and links to their modal dossier
- restyle the atlas view so the Expedition Observer and Archive Overview display side by side and adjust supporting styles
- remove the unused export button from the catalogue toolbar and update scripting to render the new directory

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd318bfcc083228b33f1974b010173