### PR TITLE
Align atlas trail and surface telemetry

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -552,6 +552,57 @@ button:hover, .badge:hover {
   mix-blend-mode: screen;
 }
 
+.map-telemetry {
+  position: absolute;
+  left: clamp(12px, 2vw, 22px);
+  top: clamp(12px, 2vw, 22px);
+  z-index: 8;
+  padding: clamp(10px, 1.8vw, 16px) clamp(12px, 2vw, 18px);
+  border-radius: 16px;
+  border: 1px solid rgba(112, 184, 255, 0.45);
+  background: linear-gradient(160deg, rgba(12, 19, 34, 0.85), rgba(12, 24, 46, 0.75));
+  box-shadow: 0 18px 32px rgba(2, 6, 18, 0.55);
+  backdrop-filter: blur(12px);
+  color: rgba(226, 236, 255, 0.86);
+  font-size: clamp(0.58rem, 0.85vw, 0.78rem);
+  display: grid;
+  gap: clamp(4px, 0.6vw, 8px);
+  pointer-events: none;
+  min-width: min(32vw, 240px);
+}
+
+.map-telemetry .telemetry-heading {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: clamp(0.62rem, 0.95vw, 0.82rem);
+  color: rgba(122, 212, 255, 0.95);
+}
+
+.map-telemetry .telemetry-pair {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  white-space: nowrap;
+}
+
+.map-telemetry .telemetry-pair span {
+  color: rgba(172, 198, 231, 0.72);
+}
+
+.map-telemetry .telemetry-pair strong {
+  color: rgba(255, 255, 255, 0.92);
+  font-weight: 600;
+}
+
+.map-telemetry .telemetry-note {
+  margin-top: 4px;
+  font-size: clamp(0.52rem, 0.75vw, 0.7rem);
+  color: rgba(212, 233, 255, 0.68);
+  line-height: 1.3;
+}
+
 .map-viewport {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- align the explorer trail SVG with the isometric projection and refresh it on resize
- slow the surveyor movement, let NPCs wander gently, and pause them during conversations
- add a telemetry overlay with location-driven time, wind, humidity, and aurora readings

## Testing
- node --check assets/app.js

------
https://chatgpt.com/codex/tasks/task_e_68de6a8ce57c83229a86737a9e18549d