### PR TITLE
Move field telemetry panel below atlas map

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1558,12 +1558,7 @@ function ensureMapStructure(){
   detail.setAttribute('aria-atomic', 'true');
   detail.hidden = true;
   map.appendChild(detail);
-  const telemetry = document.createElement('div');
-  telemetry.className = 'map-telemetry';
-  telemetry.setAttribute('aria-live', 'polite');
-  telemetry.setAttribute('aria-atomic', 'true');
-  telemetry.textContent = 'Telemetry calibrating…';
-  map.appendChild(telemetry);
+  const telemetry = document.getElementById('telemetry-readout');
   map._layers = {
     viewport,
     world,
@@ -2370,6 +2365,7 @@ function renderMapTelemetry(){
   const ex = state.explorer;
   if(!ex){
     el.textContent = 'Telemetry calibrating…';
+    el.classList.add('muted');
     return;
   }
   const zone = findZoneForCoordinate(ex.x, ex.y);
@@ -2389,14 +2385,16 @@ function renderMapTelemetry(){
   const humidity = clampNumber(55 + (1 - locationFactor) * 28 + Math.cos(elapsed / 9 + zoneSeed * 0.3) * 14, 24, 97);
   const temperature = clampNumber(18 + Math.sin(elapsed / 11 + zoneSeed * 0.2) * 6 - locationFactor * 4, 6, 32);
   const aurora = clampNumber(38 + drift * 48 + (ex.sceneEvent ? 12 : 0), 20, 98);
+  el.classList.remove('muted');
   el.innerHTML = `
-    <div class="telemetry-heading">Field Telemetry</div>
-    <div class="telemetry-pair"><span>Locale</span><strong>${locationName}</strong></div>
-    <div class="telemetry-pair"><span>Time</span><strong>${timeLabel}</strong></div>
-    <div class="telemetry-pair"><span>Wind</span><strong>${wind.toFixed(1)} knots</strong></div>
-    <div class="telemetry-pair"><span>Humidity</span><strong>${Math.round(humidity)}%</strong></div>
-    <div class="telemetry-pair"><span>Ambient</span><strong>${temperature.toFixed(1)}°C</strong></div>
-    <div class="telemetry-pair"><span>Aurora Flux</span><strong>${Math.round(aurora)}%</strong></div>
+    <div class="telemetry-grid">
+      <div class="telemetry-pair"><span>Locale</span><strong>${locationName}</strong></div>
+      <div class="telemetry-pair"><span>Time</span><strong>${timeLabel}</strong></div>
+      <div class="telemetry-pair"><span>Wind</span><strong>${wind.toFixed(1)} knots</strong></div>
+      <div class="telemetry-pair"><span>Humidity</span><strong>${Math.round(humidity)}%</strong></div>
+      <div class="telemetry-pair"><span>Ambient</span><strong>${temperature.toFixed(1)}°C</strong></div>
+      <div class="telemetry-pair"><span>Aurora Flux</span><strong>${Math.round(aurora)}%</strong></div>
+    </div>
     ${zoneSubtitle ? `<div class="telemetry-note">${zoneSubtitle}</div>` : ''}
   `;
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -461,7 +461,6 @@ button:hover, .badge:hover {
 .observer-panel {
   justify-self: stretch;
   width: 100%;
-  max-width: 520px;
 }
 
 .map-header {
@@ -552,55 +551,58 @@ button:hover, .badge:hover {
   mix-blend-mode: screen;
 }
 
-.map-telemetry {
-  position: absolute;
-  left: clamp(12px, 2vw, 22px);
-  top: clamp(12px, 2vw, 22px);
-  z-index: 8;
-  padding: clamp(10px, 1.8vw, 16px) clamp(12px, 2vw, 18px);
-  border-radius: 16px;
-  border: 1px solid rgba(112, 184, 255, 0.45);
-  background: linear-gradient(160deg, rgba(12, 19, 34, 0.85), rgba(12, 24, 46, 0.75));
-  box-shadow: 0 18px 32px rgba(2, 6, 18, 0.55);
-  backdrop-filter: blur(12px);
-  color: rgba(226, 236, 255, 0.86);
-  font-size: clamp(0.58rem, 0.85vw, 0.78rem);
+.telemetry-panel {
+  background: linear-gradient(135deg, rgba(26, 31, 52, 0.95), rgba(17, 22, 40, 0.95));
+  border: 1px solid var(--accent-purple);
+  border-radius: 26px;
+  padding: 28px;
+  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.45);
   display: grid;
-  gap: clamp(4px, 0.6vw, 8px);
-  pointer-events: none;
-  min-width: min(32vw, 240px);
+  gap: 20px;
+  justify-self: stretch;
+  width: 100%;
 }
 
-.map-telemetry .telemetry-heading {
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: clamp(0.62rem, 0.95vw, 0.82rem);
-  color: rgba(122, 212, 255, 0.95);
+.telemetry-body {
+  display: grid;
+  gap: 16px;
+  font-family: 'Crimson Text', serif;
+  font-size: 0.95rem;
+  color: rgba(232, 227, 211, 0.88);
 }
 
-.map-telemetry .telemetry-pair {
+.telemetry-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.telemetry-pair {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  gap: 12px;
-  white-space: nowrap;
+  gap: 16px;
+  font-family: 'Inconsolata', monospace;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  color: rgba(172, 198, 231, 0.85);
 }
 
-.map-telemetry .telemetry-pair span {
-  color: rgba(172, 198, 231, 0.72);
-}
-
-.map-telemetry .telemetry-pair strong {
+.telemetry-pair strong {
   color: rgba(255, 255, 255, 0.92);
-  font-weight: 600;
+  font-family: 'Crimson Text', serif;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+  text-transform: none;
 }
 
-.map-telemetry .telemetry-note {
+.telemetry-note {
   margin-top: 4px;
-  font-size: clamp(0.52rem, 0.75vw, 0.7rem);
-  color: rgba(212, 233, 255, 0.68);
-  line-height: 1.3;
+  font-family: 'Inconsolata', monospace;
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  color: rgba(212, 175, 55, 0.78);
+  text-transform: uppercase;
 }
 
 .map-viewport {
@@ -1740,11 +1742,15 @@ header .right {
   }
 
   .atlas-overview-grid {
-    grid-template-columns: minmax(320px, 520px) minmax(0, 1fr);
+    grid-template-columns: repeat(2, minmax(320px, 1fr));
     align-items: start;
   }
 
   .observer-panel {
+    max-width: none;
+  }
+
+  .telemetry-panel {
     max-width: none;
   }
 }
@@ -1759,7 +1765,7 @@ header .right {
   }
 
   .atlas-overview-grid {
-    grid-template-columns: minmax(360px, 560px) minmax(0, 1fr);
+    grid-template-columns: repeat(2, minmax(360px, 1fr));
     gap: 40px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -37,6 +37,13 @@
             </div>
           </section>
           <div class="atlas-overview-grid">
+            <section class="telemetry-panel" aria-live="polite" aria-label="Field telemetry readouts">
+              <div class="panel-header">
+                <h2>Field Telemetry</h2>
+                <p>Atmospheric readings streaming from the surveyor's instruments.</p>
+              </div>
+              <div id="telemetry-readout" class="telemetry-body muted">Telemetry calibrating…</div>
+            </section>
             <section class="observer-panel" aria-live="polite" aria-label="Automated expedition tracker">
               <div class="panel-header">
                 <h2>Expedition Observer</h2>


### PR DESCRIPTION
## Summary
- add a dedicated Field Telemetry panel below the atlas map alongside the Expedition Observer
- restyle telemetry readouts to match the observer card and update the atlas overview grid layout
- update the telemetry renderer to target the new panel container and refresh its markup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de74c879088322940daed9206adbd1