### PR TITLE
Stabilize map labels and slow simulation pacing

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -644,9 +644,9 @@ button:hover, .badge:hover {
   position: absolute;
   inset: 7% 9% 18% 9%;
   background-image:
-    repeating-linear-gradient(150deg, rgba(112, 184, 255, 0.08) 0, rgba(112, 184, 255, 0.08) 1px, transparent 1px, transparent 18px),
-    repeating-linear-gradient(30deg, rgba(212, 175, 55, 0.08) 0, rgba(212, 175, 55, 0.08) 1px, transparent 1px, transparent 18px);
-  opacity: 0.6;
+    repeating-linear-gradient(150deg, rgba(112, 184, 255, 0.08) 0, rgba(112, 184, 255, 0.08) 1px, transparent 1px, transparent 26px),
+    repeating-linear-gradient(30deg, rgba(212, 175, 55, 0.08) 0, rgba(212, 175, 55, 0.08) 1px, transparent 1px, transparent 26px);
+  opacity: 0.52;
   mix-blend-mode: screen;
 }
 


### PR DESCRIPTION
## Summary
- expand the projected landscape so markers and zones have more breathing room on the map
- cache zone label placements and widen fallback offsets to prevent jitter when avoiding markers
- ease the simulation pace by slowing explorer/NPC movement, lengthening pauses, and softening the map ground pattern density

## Testing
- Loaded index.html in the browser

------
https://chatgpt.com/codex/tasks/task_e_68de78d05ab88322bab6fcdcb6541f15