### PR TITLE
Add dynamic scene events with map markers

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -669,6 +669,93 @@ button:hover, .badge:hover {
   pointer-events: auto;
 }
 
+.map-layer-events {
+  z-index: 5;
+}
+
+.map-layer-events .map-event {
+  pointer-events: auto;
+}
+
+.map-event {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.35rem;
+  border-radius: 0.65rem;
+  background: rgba(14, 22, 36, 0.78);
+  border: 1px solid rgba(120, 180, 255, 0.4);
+  box-shadow: 0 12px 28px rgba(10, 20, 32, 0.45);
+  color: rgba(220, 235, 255, 0.9);
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  font-size: 0.7rem;
+  line-height: 0.9rem;
+  text-align: center;
+  white-space: pre;
+  min-width: 2.4rem;
+  transition: transform 0.25s ease, opacity 0.3s ease, box-shadow 0.3s ease;
+}
+
+.map-event:hover,
+.map-event:focus-visible {
+  transform: translate(-50%, -50%) scale(1.04);
+  box-shadow: 0 16px 32px rgba(24, 48, 72, 0.5);
+}
+
+.map-event pre {
+  margin: 0;
+  font: inherit;
+  line-height: inherit;
+  letter-spacing: 0.08em;
+}
+
+.map-event-caption {
+  margin-top: 0.1rem;
+  font-size: 0.55rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.map-event.type-weather {
+  background: rgba(20, 34, 54, 0.85);
+  border-color: rgba(132, 208, 255, 0.6);
+  color: rgba(180, 228, 255, 0.95);
+}
+
+.map-event.type-encounter {
+  background: rgba(46, 24, 52, 0.85);
+  border-color: rgba(255, 132, 196, 0.6);
+  color: rgba(255, 196, 228, 0.95);
+}
+
+.map-event.type-phenomenon {
+  background: rgba(24, 34, 64, 0.82);
+  border-color: rgba(176, 196, 255, 0.6);
+  color: rgba(212, 228, 255, 0.95);
+}
+
+.map-event.type-bloom,
+.map-event.type-bloom-wilt,
+.map-event.type-bloom-regrowth {
+  background: rgba(18, 46, 34, 0.85);
+  border-color: rgba(136, 232, 182, 0.6);
+  color: rgba(196, 255, 220, 0.95);
+}
+
+.map-event.type-bloom-wilt {
+  opacity: 0.82;
+  border-style: dashed;
+}
+
+.map-event.type-generic {
+  background: rgba(32, 32, 52, 0.82);
+  border-color: rgba(148, 148, 188, 0.5);
+}
+
 .map-layer-npcs {
   z-index: 5;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- extend scene events with weather, encounter, and bloom cycles that influence explorer routing and pace
- render new ASCII-styled map event markers with dedicated styling on a separate overlay layer
- introduce flora dormancy and regrowth handling so bloom events temporarily hide entries and spawn regrowth markers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de7e63ba748322b2502fcc99a85a76