### PR TITLE
Switch map rendering to top-down layout

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -173,18 +173,10 @@ const SCENE_EVENTS = [
 ];
 
 const ISO_PROJECTION = (()=>{
-  const angle = Math.PI / 6;
-  const cos = Math.cos(angle);
-  const sin = Math.sin(angle);
-  const rangeX = cos * 100;
-  const marginX = 14;
-  const marginYTop = 10;
-  const marginYBottom = 18;
+  const marginX = 12;
+  const marginYTop = 8;
+  const marginYBottom = 12;
   return {
-    angle,
-    cos,
-    sin,
-    rangeX,
     marginX,
     marginYTop,
     marginYBottom,
@@ -1693,12 +1685,10 @@ function applyLandscapeSpread(value){
 
 function projectIsoPoint(x, y){
   if(x == null || y == null) return { left: 50, top: 50 };
-  const sx = applyLandscapeSpread(x);
-  const sy = applyLandscapeSpread(y);
-  const rawX = ((sx - sy) * ISO_PROJECTION.cos + ISO_PROJECTION.rangeX) / (ISO_PROJECTION.rangeX * 2);
-  const rawY = (sx + sy) * ISO_PROJECTION.sin / 100;
-  const left = rawX * ISO_PROJECTION.scaleX + ISO_PROJECTION.marginX / 2;
-  const top = rawY * ISO_PROJECTION.scaleY + ISO_PROJECTION.marginYTop;
+  const sx = clampNumber(applyLandscapeSpread(x), 0, 100);
+  const sy = clampNumber(applyLandscapeSpread(y), 0, 100);
+  const left = ISO_PROJECTION.marginX / 2 + (sx / 100) * ISO_PROJECTION.scaleX;
+  const top = ISO_PROJECTION.marginYTop + (sy / 100) * ISO_PROJECTION.scaleY;
   return {
     left: Math.min(100, Math.max(0, left)),
     top: Math.min(100, Math.max(0, top)),
@@ -1709,13 +1699,12 @@ function projectIsoSize(width, height){
   const w = Math.max(0, Number.isFinite(width) ? width : 0);
   const hSource = Number.isFinite(height) ? height : width;
   const h = Math.max(0, hSource);
-  const isoWidth = (w * ISO_PROJECTION.cos / (ISO_PROJECTION.rangeX * 2)) * ISO_PROJECTION.scaleX;
-  const isoHeight = (h * ISO_PROJECTION.sin / 100) * ISO_PROJECTION.scaleY;
-  const scaledWidth = isoWidth * MAP_ZONE_SIZE_SCALE;
-  const scaledHeight = isoHeight * MAP_ZONE_SIZE_SCALE;
+  const scaledWidth = (w / 100) * ISO_PROJECTION.scaleX * MAP_ZONE_SIZE_SCALE;
+  const scaledHeight = (h / 100) * ISO_PROJECTION.scaleY * MAP_ZONE_SIZE_SCALE;
+  const minSize = 6;
   return {
-    width: Math.min(ISO_PROJECTION.scaleX, Math.max(scaledWidth, 5)),
-    height: Math.min(ISO_PROJECTION.scaleY, Math.max(scaledHeight, Math.max(scaledWidth * 0.65, 4))),
+    width: Math.min(ISO_PROJECTION.scaleX, Math.max(scaledWidth, minSize)),
+    height: Math.min(ISO_PROJECTION.scaleY, Math.max(scaledHeight, minSize)),
   };
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -636,23 +636,24 @@ button:hover, .badge:hover {
 
 .map-layer-topology {
   z-index: 2;
-  clip-path: polygon(4% 6%, 96% 6%, 100% 62%, 50% 88%, 0% 62%);
+  border-radius: 28px;
   background:
-    linear-gradient(185deg, rgba(28, 38, 64, 0.96), rgba(14, 20, 37, 0.94) 55%, rgba(7, 12, 26, 0.92)),
-    radial-gradient(circle at 50% 18%, rgba(212, 175, 55, 0.18), transparent 65%);
+    radial-gradient(circle at 50% 38%, rgba(46, 72, 118, 0.75), rgba(12, 18, 32, 0.92) 68%),
+    linear-gradient(180deg, rgba(14, 24, 42, 0.78), rgba(8, 14, 26, 0.92));
   border: 1px solid rgba(124, 111, 167, 0.38);
-  box-shadow: inset 0 -18px 35px rgba(0, 0, 0, 0.55), 0 30px 45px rgba(0, 0, 0, 0.55);
+  box-shadow: inset 0 0 32px rgba(0, 0, 0, 0.4), 0 30px 45px rgba(0, 0, 0, 0.55);
   overflow: hidden;
 }
 
 .map-layer-topology::before {
   content: '';
   position: absolute;
-  inset: 6% 9% 18% 9%;
+  inset: 7%;
+  border-radius: 22px;
   background-image:
-    repeating-linear-gradient(150deg, rgba(112, 184, 255, 0.08) 0, rgba(112, 184, 255, 0.08) 1px, transparent 1px, transparent 26px),
-    repeating-linear-gradient(30deg, rgba(212, 175, 55, 0.08) 0, rgba(212, 175, 55, 0.08) 1px, transparent 1px, transparent 26px);
-  opacity: 0.48;
+    repeating-linear-gradient(0deg, rgba(112, 184, 255, 0.08) 0, rgba(112, 184, 255, 0.08) 1px, transparent 1px, transparent 22px),
+    repeating-linear-gradient(90deg, rgba(212, 175, 55, 0.08) 0, rgba(212, 175, 55, 0.08) 1px, transparent 1px, transparent 22px);
+  opacity: 0.42;
   mix-blend-mode: screen;
 }
 
@@ -660,11 +661,12 @@ button:hover, .badge:hover {
   content: '';
   position: absolute;
   inset: 0;
+  border-radius: inherit;
   background:
-    radial-gradient(circle at 50% 24%, rgba(148, 210, 255, 0.18), transparent 58%),
+    radial-gradient(circle at 50% 24%, rgba(148, 210, 255, 0.18), transparent 60%),
     radial-gradient(circle at 32% 78%, rgba(122, 188, 160, 0.12), transparent 65%);
   mix-blend-mode: lighten;
-  opacity: 0.7;
+  opacity: 0.65;
 }
 
 .map-topology-features {
@@ -678,13 +680,13 @@ button:hover, .badge:hover {
   transform: translate(-50%, -50%) rotate(var(--topology-rotation, 0deg));
   width: var(--topology-width, 18%);
   height: var(--topology-height, 18%);
-  border-radius: 56% 44% 52% 48% / 48% 58% 42% 52%;
-  opacity: calc(0.62 + (var(--topology-intensity, 1) - 1) * 0.25);
-  filter: drop-shadow(0 22px 36px rgba(0, 0, 0, 0.42));
+  border-radius: 50%;
+  opacity: calc(0.58 + (var(--topology-intensity, 1) - 1) * 0.28);
+  filter: drop-shadow(0 12px 28px rgba(0, 0, 0, 0.42));
   overflow: hidden;
   mix-blend-mode: screen;
   background:
-    radial-gradient(circle at 50% 48%, rgba(42, 86, 78, 0.6), rgba(18, 32, 36, 0.25) 78%);
+    radial-gradient(circle at 50% 50%, rgba(42, 86, 78, 0.6), rgba(18, 32, 36, 0.25) 78%);
 }
 
 .map-topology-feature::before {


### PR DESCRIPTION
## Summary
- replace the isometric projection math with a top-down coordinate mapping for the atlas
- restyle the map container and topology features so the UI reads as a top-down layout instead of an isometric diamond

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de876a9088832280a93ee6066062bf