### PR TITLE
Move event key below observer and render ASCII map zones

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -338,6 +338,12 @@ button:hover, .badge:hover {
   gap: 32px;
 }
 
+.atlas-overview-grid .map-event-key {
+  margin-top: 0;
+  width: 100%;
+  align-self: stretch;
+}
+
 .inventory-board {
   background: linear-gradient(135deg, rgba(26, 31, 52, 0.95), rgba(12, 18, 35, 0.92));
   border: 1px solid rgba(124, 111, 167, 0.45);
@@ -782,6 +788,7 @@ button:hover, .badge:hover {
   }
 }
 
+
 .map-zone {
   position: absolute;
   transform: translate(-50%, -50%);
@@ -791,63 +798,57 @@ button:hover, .badge:hover {
   -webkit-clip-path: var(--zone-clip);
   border-radius: 0;
   overflow: hidden;
-  background:
-    linear-gradient(var(--zone-orientation), rgba(110, 148, 212, 0.18), rgba(36, 58, 112, 0.12) 52%, rgba(24, 36, 76, 0.28)),
-    radial-gradient(120% 90% at 54% 26%, rgba(142, 129, 196, 0.46), transparent 70%),
-    radial-gradient(130% 120% at 48% 78%, rgba(67, 108, 196, 0.24), transparent 74%),
-    linear-gradient(180deg, rgba(18, 24, 44, 0.88), rgba(8, 12, 26, 0.82));
-  border: 1.2px solid rgba(124, 111, 167, 0.42);
-  box-shadow: 0 18px 42px rgba(34, 46, 86, 0.36);
+  background: transparent;
+  border: 1.2px solid rgba(124, 111, 167, 0.35);
+  box-shadow: 0 12px 32px rgba(18, 20, 46, 0.46);
   pointer-events: none;
   z-index: 1;
-  opacity: 0.56;
-  transition: opacity 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease, transform 0.35s ease;
+  color: rgba(212, 205, 186, 0.55);
+  transition: color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, transform 0.35s ease;
 }
 
-.map-zone::before,
-.map-zone::after {
-  content: '';
+.map-zone-ascii {
   position: absolute;
   inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6%;
+  font-family: 'Fira Code', 'Source Code Pro', 'Inconsolata', monospace;
+  font-size: clamp(0.42rem, 0.8vw, 0.62rem);
+  line-height: 1.1;
+  letter-spacing: 0.08em;
+  white-space: pre;
+  text-align: center;
+  color: currentColor;
+  text-shadow: 0 0 14px rgba(212, 175, 55, 0.18);
   pointer-events: none;
-  clip-path: inherit;
-  -webkit-clip-path: inherit;
-}
-
-.map-zone::before {
-  background: radial-gradient(circle at 50% 34%, rgba(212, 175, 55, 0.22), transparent 70%);
+  opacity: 0.85;
   mix-blend-mode: screen;
-  opacity: 0.45;
-}
-
-.map-zone::after {
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: inset 0 0 18px rgba(212, 175, 55, 0.12);
-  opacity: 0.55;
 }
 
 .map-zone.active {
-  opacity: 0.96;
-  border-color: rgba(212, 175, 55, 0.68);
-  box-shadow: 0 24px 50px rgba(212, 175, 55, 0.32);
+  color: rgba(232, 227, 211, 0.82);
+  border-color: rgba(212, 175, 55, 0.58);
+  box-shadow: 0 18px 44px rgba(212, 175, 55, 0.28);
   transform: translate(-50%, -50%) scale(1.04);
 }
 
 .map-zone.selected {
-  opacity: 1;
-  border-color: rgba(212, 175, 55, 0.82);
-  box-shadow: 0 26px 58px rgba(212, 175, 55, 0.38);
+  color: rgba(255, 249, 226, 0.92);
+  border-color: rgba(212, 175, 55, 0.75);
+  box-shadow: 0 22px 54px rgba(212, 175, 55, 0.35);
   transform: translate(-50%, -50%) scale(1.07);
 }
 
-.map-zone.active::after {
-  border-color: rgba(255, 255, 255, 0.12);
-  opacity: 0.68;
+.map-zone.active .map-zone-ascii {
+  opacity: 0.92;
+  text-shadow: 0 0 18px rgba(212, 175, 55, 0.26);
 }
 
-.map-zone.selected::after {
-  border-color: rgba(255, 255, 255, 0.18);
-  opacity: 0.78;
+.map-zone.selected .map-zone-ascii {
+  opacity: 1;
+  text-shadow: 0 0 22px rgba(212, 175, 55, 0.4);
 }
 
 .map-zone.active .map-zone-label {
@@ -2037,6 +2038,10 @@ header .right {
     align-items: start;
   }
 
+  .atlas-overview-grid .map-event-key {
+    grid-column: 2;
+  }
+
   .observer-panel {
     max-width: none;
   }
@@ -2058,6 +2063,10 @@ header .right {
   .atlas-overview-grid {
     grid-template-columns: repeat(2, minmax(360px, 1fr));
     gap: 40px;
+  }
+
+  .atlas-overview-grid .map-event-key {
+    grid-column: 2;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -35,10 +35,6 @@
               <span class="legend-item"><span class="legend-dot npc-new"></span> NPC with new dialogue</span>
               <span class="legend-item"><span class="legend-dot dim"></span> Outside current filters</span>
             </div>
-            <section id="map-event-key" class="map-event-key" aria-label="Random event glyph key">
-              <h3>Random Event Key</h3>
-              <p class="map-event-key-placeholder small muted">Glyph catalogue calibrating…</p>
-            </section>
           </section>
           <div class="atlas-overview-grid">
             <section class="telemetry-panel" aria-live="polite" aria-label="Field telemetry readouts">
@@ -64,6 +60,10 @@
                 </div>
                 <ol id="explorer-log" class="observer-log" aria-label="Recent specimens catalogued"></ol>
               </div>
+            </section>
+            <section id="map-event-key" class="map-event-key" aria-label="Random event glyph key">
+              <h3>Random Event Key</h3>
+              <p class="map-event-key-placeholder small muted">Glyph catalogue calibrating…</p>
             </section>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- reposition the random event key beneath the Expedition Observer panel in the atlas overview grid
- restyle the atlas zones to use ASCII overlays instead of color fills and adjust related hover/selection states
- generate ASCII art outlines for each zone dynamically based on zone dimensions and orientation

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68de94aeaff8832297f504873e545cfb