### PR TITLE
Add ASCII topography layer to map

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -644,6 +644,28 @@ button:hover, .badge:hover {
   z-index: 3;
 }
 
+.map-layer-topography {
+  z-index: 1;
+  opacity: 0.92;
+}
+
+.map-topography-ascii {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  padding: 8% 6%;
+  font-family: 'Fira Code', 'Source Code Pro', 'Inconsolata', monospace;
+  font-size: clamp(0.38rem, 0.62vw, 0.58rem);
+  line-height: 1.05;
+  letter-spacing: 0.06em;
+  white-space: pre;
+  text-align: center;
+  color: rgba(144, 196, 228, 0.55);
+  text-shadow: 0 0 14px rgba(48, 118, 176, 0.24);
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
 
 .map-layer-zones {
   z-index: 3;
@@ -823,7 +845,7 @@ button:hover, .badge:hover {
   color: currentColor;
   text-shadow: 0 0 14px rgba(212, 175, 55, 0.18);
   pointer-events: none;
-  opacity: 0.85;
+  opacity: 0.38;
   mix-blend-mode: screen;
 }
 
@@ -842,12 +864,12 @@ button:hover, .badge:hover {
 }
 
 .map-zone.active .map-zone-ascii {
-  opacity: 0.92;
+  opacity: 0.62;
   text-shadow: 0 0 18px rgba(212, 175, 55, 0.26);
 }
 
 .map-zone.selected .map-zone-ascii {
-  opacity: 1;
+  opacity: 0.78;
   text-shadow: 0 0 22px rgba(212, 175, 55, 0.4);
 }
 

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -7,10 +7,100 @@ const state = {
   tag: 'All',
 };
 
+const WORLD_TOPOGRAPHY = Object.freeze({
+  gridWidth: 64,
+  gridHeight: 36,
+  seed: 0.618,
+});
+
+const WORLD_TOPOGRAPHY_PALETTE = [
+  { limit: -1.15, pattern: '~~' },
+  { limit: -0.7, pattern: 'vv' },
+  { limit: -0.25, pattern: '--' },
+  { limit: 0.2, pattern: '..' },
+  { limit: 0.6, pattern: '::' },
+  { limit: 1, pattern: '/\\' },
+  { limit: Infinity, pattern: '^^' },
+];
+
+const WORLD_TOPOGRAPHY_RIDGE_PATTERNS = [
+  { limit: 15, pattern: '||' },
+  { limit: 35, pattern: '/\\' },
+  { limit: 70, pattern: '--' },
+  { limit: 110, pattern: '\\/' },
+  { limit: 145, pattern: '\\' },
+  { limit: 180, pattern: '||' },
+];
+
+let cachedTopographyAscii = null;
+
+const MAP_TOPOLOGY_FEATURES = [
+  {
+    id: 'choir-uplands',
+    name: 'Choir Uplands',
+    type: 'hill',
+    x: 40,
+    y: 34,
+    width: 24,
+    height: 18,
+    rotation: -6,
+    intensity: 1.15,
+  },
+  {
+    id: 'sunken-promenade',
+    name: 'Sunken Promenade Basin',
+    type: 'valley',
+    x: 50,
+    y: 70,
+    width: 30,
+    height: 20,
+    rotation: 8,
+    intensity: 1.05,
+  },
+  {
+    id: 'ridge-of-sighs',
+    name: 'Ridge of Sighs',
+    type: 'ridge',
+    x: 28,
+    y: 52,
+    width: 38,
+    height: 16,
+    rotation: -18,
+    intensity: 1.1,
+  },
+  {
+    id: 'palace-terraces',
+    name: 'Palace Terraces',
+    type: 'hill',
+    x: 72,
+    y: 48,
+    width: 28,
+    height: 22,
+    rotation: 12,
+    intensity: 1.2,
+  },
+  {
+    id: 'deepway-sink',
+    name: 'Deepway Sink',
+    type: 'valley',
+    x: 72,
+    y: 82,
+    width: 34,
+    height: 18,
+    rotation: 18,
+    intensity: 0.9,
+  },
+];
+
 function renderMapMarkers(){
   const map = document.querySelector('#map');
   if(!map) return;
   map.innerHTML = '';
+  const ascii = document.createElement('pre');
+  ascii.className = 'map-topography-ascii';
+  ascii.setAttribute('aria-hidden', 'true');
+  ascii.textContent = generateWorldTopographyAscii();
+  map.appendChild(ascii);
   const filteredIds = new Set(state.filtered.map(e=>e.id));
   state.entries.filter(e=>e.location).forEach(e=>{
     const marker = document.createElement('button');
@@ -138,6 +228,124 @@ function restoreFromHash(){
     const e = state.entries.find(e=>e.id===id);
     if(e) openModal(e);
   }
+}
+
+function generateWorldTopographyAscii(){
+  if(cachedTopographyAscii) return cachedTopographyAscii;
+  const width = WORLD_TOPOGRAPHY.gridWidth;
+  const height = WORLD_TOPOGRAPHY.gridHeight;
+  const rows = [];
+  for(let gy = 0; gy < height; gy += 1){
+    const py = height <= 1 ? 0 : (gy / (height - 1)) * 100;
+    let row = '';
+    for(let gx = 0; gx < width; gx += 1){
+      const px = width <= 1 ? 0 : (gx / (width - 1)) * 100;
+      const sample = computeWorldTopographySample(px, py);
+      let pattern = pickTopographyPattern(sample);
+      const idx = Math.abs(Math.floor(gx + gy)) % pattern.length;
+      let char = pattern[idx] || pattern[0] || '.';
+      if(sample.elevation > 1.4 && sample.hillInfluence > 0.55 && ((gx + gy) % 5 === 0)){
+        char = 'A';
+      } else if(sample.elevation > 1.75 && sample.hillInfluence > 0.7 && ((gx * 3 + gy) % 7 === 0)){
+        char = 'M';
+      } else if(sample.elevation < -0.85 && sample.valleyInfluence > 0.5 && ((gx + gy * 2) % 4 === 0)){
+        char = 'v';
+      }
+      row += char;
+    }
+    rows.push(row);
+  }
+  cachedTopographyAscii = rows.join('\n');
+  return cachedTopographyAscii;
+}
+
+function computeWorldTopographySample(px, py){
+  let elevation = ((py / 100) - 0.5) * 0.9;
+  elevation += ((px / 100) - 0.5) * 0.4;
+  let hillInfluence = 0;
+  let valleyInfluence = 0;
+  let ridgeInfluence = 0;
+  let ridgeRotation = null;
+  MAP_TOPOLOGY_FEATURES.forEach(feature => {
+    if(!feature) return;
+    const spanX = Math.max(6, Number.isFinite(feature.width) ? feature.width : 20);
+    const spanY = Math.max(6, Number.isFinite(feature.height) ? feature.height : spanX);
+    const dx = px - feature.x;
+    const dy = py - feature.y;
+    const distX = dx / (spanX * 0.5);
+    const distY = dy / (spanY * 0.5);
+    const distance = Math.hypot(distX, distY);
+    if(distance > 2.2) return;
+    const falloff = Math.max(0, 1 - (distance ** 1.35));
+    if(falloff <= 0) return;
+    const intensity = Number.isFinite(feature.intensity) ? feature.intensity : 1;
+    const influence = falloff * intensity;
+    const type = feature.type || 'hill';
+    if(type === 'valley' || type === 'sink'){
+      elevation -= influence * 1.2;
+      valleyInfluence = Math.max(valleyInfluence, influence);
+    } else if(type === 'ridge'){
+      elevation += influence * 0.9;
+      if(influence > ridgeInfluence){
+        ridgeInfluence = influence;
+        ridgeRotation = feature.rotation ?? 0;
+      }
+    } else {
+      elevation += influence * 1.3;
+      hillInfluence = Math.max(hillInfluence, influence);
+      if(influence > ridgeInfluence && Number.isFinite(feature.rotation)){
+        ridgeInfluence = influence * 0.6;
+        ridgeRotation = feature.rotation;
+      }
+    }
+  });
+  const jitter = seededJitter(WORLD_TOPOGRAPHY.seed, px * 1.71 + py * 2.13, 0.55);
+  const drift = seededJitter(WORLD_TOPOGRAPHY.seed, px * -0.42 + py * 0.58, 0.35);
+  elevation += jitter * 0.35 + drift * 0.25;
+  return { elevation, hillInfluence, valleyInfluence, ridgeInfluence, ridgeRotation };
+}
+
+function pickTopographyPattern(sample){
+  if(sample.ridgeInfluence > 0.55 && Number.isFinite(sample.ridgeRotation)){
+    return pickOrientationPattern(sample.ridgeRotation);
+  }
+  if(sample.valleyInfluence > 0.6){
+    return '~~';
+  }
+  let pattern = '::';
+  for(const option of WORLD_TOPOGRAPHY_PALETTE){
+    if(sample.elevation <= option.limit){
+      pattern = option.pattern;
+      break;
+    }
+  }
+  if(sample.hillInfluence > 0.65 && sample.elevation > 0.4){
+    const oriented = Number.isFinite(sample.ridgeRotation)
+      ? pickOrientationPattern(sample.ridgeRotation)
+      : null;
+    if(oriented) pattern = oriented;
+  }
+  return pattern;
+}
+
+function pickOrientationPattern(rotation){
+  const normalized = Math.abs(rotation % 180);
+  for(const option of WORLD_TOPOGRAPHY_RIDGE_PATTERNS){
+    if(normalized <= option.limit){
+      return option.pattern;
+    }
+  }
+  const fallback = WORLD_TOPOGRAPHY_RIDGE_PATTERNS[WORLD_TOPOGRAPHY_RIDGE_PATTERNS.length - 1];
+  return fallback ? fallback.pattern : '||';
+}
+
+function seededRandom(seed, index = 0){
+  const value = Math.sin((seed || 1) * 1337.13 + index * 97.73) * 43758.5453;
+  return value - Math.floor(value);
+}
+
+function seededJitter(seed, index, amplitude = 1){
+  return (seededRandom(seed, index) - 0.5) * 2 * amplitude;
 }
 
 async function main(){

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -31,6 +31,7 @@ button:hover{border-color:var(--accent)}
 .marker:focus-visible{outline:2px solid #fff;outline-offset:2px}
 .marker span{position:absolute;width:40%;height:40%;border-radius:50%;background:#121622}
 .marker.dim{background:rgba(147,152,172,.65);border-color:rgba(211,214,224,.4);box-shadow:none;animation:none}
+.map-topography-ascii{position:absolute;inset:0;margin:0;padding:8% 6%;font-family:'Fira Code','Source Code Pro','Inconsolata',monospace;font-size:clamp(.36rem,.6vw,.56rem);line-height:1.05;letter-spacing:.06em;white-space:pre;text-align:center;color:rgba(144,196,228,.55);text-shadow:0 0 14px rgba(48,118,176,.24);mix-blend-mode:screen;pointer-events:none;opacity:.92}
 .map-legend{display:flex;gap:16px;flex-wrap:wrap;margin-top:14px;color:var(--muted)}
 .legend-item{display:inline-flex;align-items:center;gap:6px}
 .legend-dot{width:10px;height:10px;border-radius:50%;background:var(--accent);border:1px solid rgba(255,255,255,.8)}


### PR DESCRIPTION
## Summary
- add a deterministic ASCII topography generator that fills the atlas background and projects hills, ridges, and valleys
- update zone overlays to sit on top of the shared ASCII terrain while easing their typography
- mirror the new ASCII terrain overlay inside the lightweight docs build for consistency

## Testing
- node --check assets/app.js
- node --check docs/assets/app.js

------
https://chatgpt.com/codex/tasks/task_e_68dea2dbbeb08322a7635fc83e9131f1