### PR TITLE
Replace ASCII map with static topography layer

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -501,149 +501,79 @@ const TOPOLOGY_FEATURE_MAP = new Map(
   MAP_TOPOLOGY_FEATURES.map(feature => [feature.id, feature])
 );
 
-const WORLD_TOPOGRAPHY = Object.freeze({
-  gridWidth: 72,
-  gridHeight: 42,
-  seed: 0.618,
-});
+const STATIC_TOPOGRAPHY_SVG = `
+  <svg class="map-topography" viewBox="0 0 1200 720" preserveAspectRatio="xMidYMid slice" aria-hidden="true" focusable="false">
+    <defs>
+      <linearGradient id="terrain-water" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#071018"/>
+        <stop offset="55%" stop-color="#0b1826"/>
+        <stop offset="100%" stop-color="#050b13"/>
+      </linearGradient>
+      <radialGradient id="terrain-glow" cx="52%" cy="38%" r="62%">
+        <stop offset="0%" stop-color="#1f3b54" stop-opacity="0.9"/>
+        <stop offset="60%" stop-color="#142941" stop-opacity="0.8"/>
+        <stop offset="100%" stop-color="#0b1826" stop-opacity="0.7"/>
+      </radialGradient>
+      <linearGradient id="terrain-fill" x1="32%" y1="12%" x2="78%" y2="88%">
+        <stop offset="0%" stop-color="#1f3951"/>
+        <stop offset="40%" stop-color="#203c4c"/>
+        <stop offset="100%" stop-color="#122332"/>
+      </linearGradient>
+      <linearGradient id="terrain-ridge" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#3d8fb6" stop-opacity="0.85"/>
+        <stop offset="50%" stop-color="#6abbe0" stop-opacity="0.8"/>
+        <stop offset="100%" stop-color="#3682ab" stop-opacity="0.85"/>
+      </linearGradient>
+      <filter id="terrain-haze" x="-15%" y="-15%" width="130%" height="130%">
+        <feGaussianBlur stdDeviation="18" result="blur"/>
+        <feBlend in="blur" in2="SourceGraphic" mode="screen"/>
+      </filter>
+    </defs>
+    <rect width="1200" height="720" fill="url(#terrain-water)"/>
+    <g class="land" filter="url(#terrain-haze)">
+      <path class="landmass" d="M132 484C134 356 244 272 398 242C512 220 624 170 734 182C850 196 938 262 970 338C1004 418 956 508 890 566C822 626 712 642 610 616C520 594 462 618 376 610C268 600 168 564 132 484Z" fill="url(#terrain-glow)"/>
+      <path class="landmass-outline" d="M152 470C154 366 250 292 396 262C500 240 612 188 722 198C826 208 904 266 932 330C962 396 926 472 868 524C812 576 710 596 618 574C520 550 462 574 384 566C288 556 190 528 152 470Z" fill="url(#terrain-fill)"/>
+    </g>
+    <g class="contours">
+      <path class="contour contour-major" d="M188 470C198 382 296 320 428 292C528 270 622 238 708 248C782 256 846 288 876 338C912 398 874 466 822 516C770 566 688 584 604 564C520 544 462 566 394 558C306 548 224 520 188 470Z"/>
+      <path class="contour contour-major" d="M236 470C248 396 320 348 430 320C512 300 596 276 674 286C734 294 786 320 810 356C842 404 812 458 770 496C726 536 656 548 586 532C514 516 460 534 400 526C324 516 266 502 236 470Z"/>
+      <path class="contour contour-tight" d="M292 468C304 410 360 368 448 348C520 332 586 320 642 330C688 338 726 356 742 382C764 420 740 456 706 486C670 516 612 524 556 510C502 496 460 510 410 502C356 494 312 486 292 468Z"/>
+      <path class="contour contour-tight" d="M338 468C348 426 394 392 460 378C516 366 570 360 612 368C646 374 676 388 688 410C704 438 686 466 660 490C632 514 584 520 540 506C494 492 458 504 420 498C380 492 350 484 338 468Z"/>
+      <path class="contour contour-fine" d="M382 470C390 440 424 414 474 404C514 396 552 392 586 398C612 402 636 414 644 430C656 452 642 474 620 494C596 514 560 518 526 508C494 498 462 508 432 504C406 500 390 490 382 470Z"/>
+      <path class="contour contour-fine" d="M430 470C438 448 464 432 500 426C530 422 560 420 582 424C602 428 620 438 626 450C636 468 624 486 604 500C582 516 552 518 526 508C502 500 474 510 450 506C438 504 432 492 430 470Z"/>
+      <path class="contour contour-major" d="M322 404C350 352 420 314 510 300C580 290 642 292 694 304C742 314 782 338 802 366"/>
+      <path class="contour contour-fine" d="M264 426C292 366 366 320 468 304"/>
+      <path class="contour contour-fine" d="M526 286C582 276 648 276 698 286"/>
+    </g>
+    <g class="ridges">
+      <path class="ridge" d="M332 344C378 310 454 286 544 278C626 270 710 284 772 320"/>
+      <path class="ridge" d="M364 310C430 268 536 244 640 250C706 254 764 272 806 298"/>
+    </g>
+    <g class="waterways">
+      <path class="river" d="M520 520C552 486 562 452 560 418C558 374 582 338 636 312"/>
+      <path class="river" d="M468 496C500 462 506 426 498 390"/>
+      <path class="lake" d="M646 370C662 354 692 348 712 360C732 372 732 396 716 414C700 432 666 438 648 424C632 412 630 388 646 370Z"/>
+      <path class="lake" d="M424 432C438 420 460 416 476 424C492 432 492 450 478 462C464 474 440 478 426 468C414 460 412 444 424 432Z"/>
+    </g>
+    <g class="highlights">
+      <path class="glow" d="M300 516C360 556 452 578 548 576C644 574 720 548 786 494"/>
+      <path class="glow" d="M248 448C292 378 380 326 496 310"/>
+    </g>
+    <g class="islands">
+      <path class="island" d="M968 420C984 404 1008 398 1028 406C1048 414 1052 432 1038 446C1024 460 996 466 978 456C962 448 954 434 968 420Z"/>
+      <path class="island" d="M204 308C214 296 234 292 250 298C266 304 268 320 256 332C244 344 222 348 208 340C196 334 194 320 204 308Z"/>
+    </g>
+  </svg>
+`;
 
-const WORLD_TOPOGRAPHY_PALETTE = [
-  { limit: -1.15, pattern: '~~' },
-  { limit: -0.7, pattern: 'vv' },
-  { limit: -0.25, pattern: '--' },
-  { limit: 0.2, pattern: '..' },
-  { limit: 0.6, pattern: '::' },
-  { limit: 1, pattern: '/\\' },
-  { limit: Infinity, pattern: '^^' },
-];
-
-const WORLD_TOPOGRAPHY_RIDGE_PATTERNS = [
-  { limit: 15, pattern: '||' },
-  { limit: 35, pattern: '/\\' },
-  { limit: 70, pattern: '--' },
-  { limit: 110, pattern: '\\/' },
-  { limit: 145, pattern: '\\' },
-  { limit: 180, pattern: '||' },
-];
-
-let cachedTopographyAscii = null;
-
-function generateWorldTopographyAscii(){
-  if(cachedTopographyAscii) return cachedTopographyAscii;
-  const width = WORLD_TOPOGRAPHY.gridWidth;
-  const height = WORLD_TOPOGRAPHY.gridHeight;
-  const rows = [];
-  for(let gy = 0; gy < height; gy += 1){
-    const py = height <= 1 ? 0 : (gy / (height - 1)) * 100;
-    let row = '';
-    for(let gx = 0; gx < width; gx += 1){
-      const px = width <= 1 ? 0 : (gx / (width - 1)) * 100;
-      const sample = computeWorldTopographySample(px, py);
-      let pattern = pickTopographyPattern(sample);
-      const charIndex = Math.abs(Math.floor(gx + gy)) % pattern.length;
-      let char = pattern[charIndex] || pattern[0] || '.';
-      if(sample.elevation > 1.35 && sample.hillInfluence > 0.55 && ((gx + gy) % 5 === 0)){
-        char = 'A';
-      } else if(sample.elevation > 1.75 && sample.hillInfluence > 0.7 && ((gx * 3 + gy) % 7 === 0)){
-        char = 'M';
-      } else if(sample.elevation < -0.85 && sample.valleyInfluence > 0.5 && ((gx + gy * 2) % 4 === 0)){
-        char = 'v';
-      }
-      row += char;
-    }
-    rows.push(row);
+function createTopographySvg(){
+  const template = document.createElement('template');
+  template.innerHTML = STATIC_TOPOGRAPHY_SVG.trim();
+  const svg = template.content.firstElementChild;
+  if(svg){
+    svg.setAttribute('aria-hidden', 'true');
   }
-  cachedTopographyAscii = rows.join('\n');
-  return cachedTopographyAscii;
-}
-
-function computeWorldTopographySample(px, py){
-  let elevation = ((py / 100) - 0.5) * 0.9;
-  elevation += ((px / 100) - 0.5) * 0.4;
-  let hillInfluence = 0;
-  let valleyInfluence = 0;
-  let ridgeInfluence = 0;
-  let ridgeRotation = null;
-  MAP_TOPOLOGY_FEATURES.forEach(feature => {
-    if(!feature) return;
-    const spanX = Math.max(6, Number.isFinite(feature.width) ? feature.width : 20);
-    const spanY = Math.max(6, Number.isFinite(feature.height) ? feature.height : spanX);
-    const dx = px - feature.x;
-    const dy = py - feature.y;
-    const distX = dx / (spanX * 0.5);
-    const distY = dy / (spanY * 0.5);
-    const distance = Math.hypot(distX, distY);
-    if(distance > 2.2) return;
-    const falloff = Math.max(0, 1 - (distance ** 1.35));
-    if(falloff <= 0) return;
-    const intensity = Number.isFinite(feature.intensity) ? feature.intensity : 1;
-    const influence = falloff * intensity;
-    const type = feature.type || 'hill';
-    if(type === 'valley' || type === 'sink'){
-      elevation -= influence * 1.2;
-      valleyInfluence = Math.max(valleyInfluence, influence);
-    } else if(type === 'ridge'){
-      elevation += influence * 0.9;
-      if(influence > ridgeInfluence){
-        ridgeInfluence = influence;
-        ridgeRotation = feature.rotation ?? 0;
-      }
-    } else {
-      elevation += influence * 1.3;
-      hillInfluence = Math.max(hillInfluence, influence);
-      if(influence > ridgeInfluence && Number.isFinite(feature.rotation)){
-        ridgeInfluence = influence * 0.6;
-        ridgeRotation = feature.rotation;
-      }
-    }
-  });
-  const jitter = seededJitter(WORLD_TOPOGRAPHY.seed, px * 1.71 + py * 2.13, 0.55);
-  const drift = seededJitter(WORLD_TOPOGRAPHY.seed, px * -0.42 + py * 0.58, 0.35);
-  elevation += jitter * 0.35 + drift * 0.25;
-  return { elevation, hillInfluence, valleyInfluence, ridgeInfluence, ridgeRotation };
-}
-
-function pickTopographyPattern(sample){
-  if(sample.ridgeInfluence > 0.55 && Number.isFinite(sample.ridgeRotation)){
-    return pickOrientationPattern(sample.ridgeRotation);
-  }
-  if(sample.valleyInfluence > 0.6){
-    return '~~';
-  }
-  let pattern = '::';
-  for(const option of WORLD_TOPOGRAPHY_PALETTE){
-    if(sample.elevation <= option.limit){
-      pattern = option.pattern;
-      break;
-    }
-  }
-  if(sample.hillInfluence > 0.65 && sample.elevation > 0.4){
-    const oriented = Number.isFinite(sample.ridgeRotation)
-      ? pickOrientationPattern(sample.ridgeRotation)
-      : null;
-    if(oriented) pattern = oriented;
-  }
-  return pattern;
-}
-
-function pickOrientationPattern(rotation){
-  const normalized = Math.abs(rotation % 180);
-  for(const option of WORLD_TOPOGRAPHY_RIDGE_PATTERNS){
-    if(normalized <= option.limit){
-      return option.pattern;
-    }
-  }
-  const fallback = WORLD_TOPOGRAPHY_RIDGE_PATTERNS[WORLD_TOPOGRAPHY_RIDGE_PATTERNS.length - 1];
-  return fallback ? fallback.pattern : '||';
-}
-
-function renderMapTopography(layers){
-  const asciiNode = layers?.topography?.ascii;
-  if(!asciiNode) return;
-  const ascii = generateWorldTopographyAscii();
-  if(ascii && asciiNode.textContent !== ascii){
-    asciiNode.textContent = ascii;
-  }
+  return svg;
 }
 
 const NPCS = [
@@ -2111,10 +2041,10 @@ function ensureMapStructure(){
   const topographyLayer = document.createElement('div');
   topographyLayer.className = 'map-layer map-layer-topography';
   topographyLayer.setAttribute('aria-hidden', 'true');
-  const topographyAscii = document.createElement('pre');
-  topographyAscii.className = 'map-topography-ascii';
-  topographyAscii.setAttribute('aria-hidden', 'true');
-  topographyLayer.appendChild(topographyAscii);
+  const topographySvg = createTopographySvg();
+  if(topographySvg){
+    topographyLayer.appendChild(topographySvg);
+  }
   const pathSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   pathSvg.classList.add('map-path');
   pathSvg.setAttribute('viewBox', '0 0 100 100');
@@ -2153,7 +2083,7 @@ function ensureMapStructure(){
   map._layers = {
     viewport,
     world,
-    topography: { layer: topographyLayer, ascii: topographyAscii },
+    topography: { layer: topographyLayer, svg: topographySvg },
     path: { svg: pathSvg, line: pathLine },
     zones: zonesLayer,
     markers: markersLayer,
@@ -2164,7 +2094,6 @@ function ensureMapStructure(){
     arrival,
     telemetry,
   };
-  renderMapTopography(map._layers);
   if(state.mapCamera){
     if(typeof state.mapCamera.manual !== 'boolean'){
       state.mapCamera.manual = false;
@@ -2445,10 +2374,7 @@ function generateZoneAsciiArt(zone, orientation){
 }
 
 function renderMapZones(layer){
-  const layers = ensureMapStructure();
-  if(layers){
-    renderMapTopography(layers);
-  }
+  ensureMapStructure();
   if(!layer) return;
   layer.innerHTML = '';
   const activeRegions = new Set(

--- a/assets/style.css
+++ b/assets/style.css
@@ -646,24 +646,96 @@ button:hover, .badge:hover {
 
 .map-layer-topography {
   z-index: 1;
-  opacity: 0.92;
+  opacity: 0.95;
 }
 
-.map-topography-ascii {
+.map-layer-topography .map-topography {
   position: absolute;
   inset: 0;
-  margin: 0;
-  padding: 8% 6%;
-  font-family: 'Fira Code', 'Source Code Pro', 'Inconsolata', monospace;
-  font-size: clamp(0.38rem, 0.62vw, 0.58rem);
-  line-height: 1.05;
-  letter-spacing: 0.06em;
-  white-space: pre;
-  text-align: center;
-  color: rgba(144, 196, 228, 0.55);
-  text-shadow: 0 0 14px rgba(48, 118, 176, 0.24);
-  mix-blend-mode: screen;
+  width: 100%;
+  height: 100%;
+  display: block;
   pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.map-topography .landmass,
+.map-topography .landmass-outline {
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.map-topography .landmass {
+  stroke: rgba(88, 164, 206, 0.28);
+  stroke-width: 4px;
+  fill-opacity: 0.82;
+}
+
+.map-topography .landmass-outline {
+  stroke: rgba(140, 208, 248, 0.24);
+  stroke-width: 2.4px;
+  fill-opacity: 0.94;
+}
+
+.map-topography .contour {
+  fill: none;
+  stroke: rgba(122, 198, 248, 0.28);
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.map-topography .contour.contour-major {
+  stroke: rgba(126, 202, 255, 0.35);
+}
+
+.map-topography .contour.contour-tight {
+  stroke-width: 1.6px;
+  stroke: rgba(154, 216, 255, 0.32);
+}
+
+.map-topography .contour.contour-fine {
+  stroke-width: 1.1px;
+  stroke: rgba(164, 224, 255, 0.22);
+  stroke-dasharray: 14 10;
+}
+
+.map-topography .ridge {
+  fill: none;
+  stroke: url(#terrain-ridge);
+  stroke-width: 2.3px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.75;
+}
+
+.map-topography .river {
+  fill: none;
+  stroke: rgba(102, 198, 255, 0.68);
+  stroke-width: 3.2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 12px rgba(90, 180, 255, 0.35));
+}
+
+.map-topography .lake {
+  fill: rgba(70, 144, 190, 0.45);
+  stroke: rgba(140, 208, 248, 0.45);
+  stroke-width: 1.3px;
+}
+
+.map-topography .glow {
+  fill: none;
+  stroke: rgba(200, 228, 255, 0.16);
+  stroke-width: 12px;
+  stroke-linecap: round;
+  filter: blur(1.2px);
+}
+
+.map-topography .island {
+  fill: rgba(38, 74, 102, 0.9);
+  stroke: rgba(140, 202, 236, 0.4);
+  stroke-width: 1.4px;
 }
 
 

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -7,32 +7,80 @@ const state = {
   tag: 'All',
 };
 
-const WORLD_TOPOGRAPHY = Object.freeze({
-  gridWidth: 64,
-  gridHeight: 36,
-  seed: 0.618,
-});
+const STATIC_TOPOGRAPHY_SVG = `
+  <svg class="map-topography" viewBox="0 0 1200 720" preserveAspectRatio="xMidYMid slice" aria-hidden="true" focusable="false">
+    <defs>
+      <linearGradient id="terrain-water" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#071018"/>
+        <stop offset="55%" stop-color="#0b1826"/>
+        <stop offset="100%" stop-color="#050b13"/>
+      </linearGradient>
+      <radialGradient id="terrain-glow" cx="52%" cy="38%" r="62%">
+        <stop offset="0%" stop-color="#1f3b54" stop-opacity="0.9"/>
+        <stop offset="60%" stop-color="#142941" stop-opacity="0.8"/>
+        <stop offset="100%" stop-color="#0b1826" stop-opacity="0.7"/>
+      </radialGradient>
+      <linearGradient id="terrain-fill" x1="32%" y1="12%" x2="78%" y2="88%">
+        <stop offset="0%" stop-color="#1f3951"/>
+        <stop offset="40%" stop-color="#203c4c"/>
+        <stop offset="100%" stop-color="#122332"/>
+      </linearGradient>
+      <linearGradient id="terrain-ridge" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#3d8fb6" stop-opacity="0.85"/>
+        <stop offset="50%" stop-color="#6abbe0" stop-opacity="0.8"/>
+        <stop offset="100%" stop-color="#3682ab" stop-opacity="0.85"/>
+      </linearGradient>
+      <filter id="terrain-haze" x="-15%" y="-15%" width="130%" height="130%">
+        <feGaussianBlur stdDeviation="18" result="blur"/>
+        <feBlend in="blur" in2="SourceGraphic" mode="screen"/>
+      </filter>
+    </defs>
+    <rect width="1200" height="720" fill="url(#terrain-water)"/>
+    <g class="land" filter="url(#terrain-haze)">
+      <path class="landmass" d="M132 484C134 356 244 272 398 242C512 220 624 170 734 182C850 196 938 262 970 338C1004 418 956 508 890 566C822 626 712 642 610 616C520 594 462 618 376 610C268 600 168 564 132 484Z" fill="url(#terrain-glow)"/>
+      <path class="landmass-outline" d="M152 470C154 366 250 292 396 262C500 240 612 188 722 198C826 208 904 266 932 330C962 396 926 472 868 524C812 576 710 596 618 574C520 550 462 574 384 566C288 556 190 528 152 470Z" fill="url(#terrain-fill)"/>
+    </g>
+    <g class="contours">
+      <path class="contour contour-major" d="M188 470C198 382 296 320 428 292C528 270 622 238 708 248C782 256 846 288 876 338C912 398 874 466 822 516C770 566 688 584 604 564C520 544 462 566 394 558C306 548 224 520 188 470Z"/>
+      <path class="contour contour-major" d="M236 470C248 396 320 348 430 320C512 300 596 276 674 286C734 294 786 320 810 356C842 404 812 458 770 496C726 536 656 548 586 532C514 516 460 534 400 526C324 516 266 502 236 470Z"/>
+      <path class="contour contour-tight" d="M292 468C304 410 360 368 448 348C520 332 586 320 642 330C688 338 726 356 742 382C764 420 740 456 706 486C670 516 612 524 556 510C502 496 460 510 410 502C356 494 312 486 292 468Z"/>
+      <path class="contour contour-tight" d="M338 468C348 426 394 392 460 378C516 366 570 360 612 368C646 374 676 388 688 410C704 438 686 466 660 490C632 514 584 520 540 506C494 492 458 504 420 498C380 492 350 484 338 468Z"/>
+      <path class="contour contour-fine" d="M382 470C390 440 424 414 474 404C514 396 552 392 586 398C612 402 636 414 644 430C656 452 642 474 620 494C596 514 560 518 526 508C494 498 462 508 432 504C406 500 390 490 382 470Z"/>
+      <path class="contour contour-fine" d="M430 470C438 448 464 432 500 426C530 422 560 420 582 424C602 428 620 438 626 450C636 468 624 486 604 500C582 516 552 518 526 508C502 500 474 510 450 506C438 504 432 492 430 470Z"/>
+      <path class="contour contour-major" d="M322 404C350 352 420 314 510 300C580 290 642 292 694 304C742 314 782 338 802 366"/>
+      <path class="contour contour-fine" d="M264 426C292 366 366 320 468 304"/>
+      <path class="contour contour-fine" d="M526 286C582 276 648 276 698 286"/>
+    </g>
+    <g class="ridges">
+      <path class="ridge" d="M332 344C378 310 454 286 544 278C626 270 710 284 772 320"/>
+      <path class="ridge" d="M364 310C430 268 536 244 640 250C706 254 764 272 806 298"/>
+    </g>
+    <g class="waterways">
+      <path class="river" d="M520 520C552 486 562 452 560 418C558 374 582 338 636 312"/>
+      <path class="river" d="M468 496C500 462 506 426 498 390"/>
+      <path class="lake" d="M646 370C662 354 692 348 712 360C732 372 732 396 716 414C700 432 666 438 648 424C632 412 630 388 646 370Z"/>
+      <path class="lake" d="M424 432C438 420 460 416 476 424C492 432 492 450 478 462C464 474 440 478 426 468C414 460 412 444 424 432Z"/>
+    </g>
+    <g class="highlights">
+      <path class="glow" d="M300 516C360 556 452 578 548 576C644 574 720 548 786 494"/>
+      <path class="glow" d="M248 448C292 378 380 326 496 310"/>
+    </g>
+    <g class="islands">
+      <path class="island" d="M968 420C984 404 1008 398 1028 406C1048 414 1052 432 1038 446C1024 460 996 466 978 456C962 448 954 434 968 420Z"/>
+      <path class="island" d="M204 308C214 296 234 292 250 298C266 304 268 320 256 332C244 344 222 348 208 340C196 334 194 320 204 308Z"/>
+    </g>
+  </svg>
+`;
 
-const WORLD_TOPOGRAPHY_PALETTE = [
-  { limit: -1.15, pattern: '~~' },
-  { limit: -0.7, pattern: 'vv' },
-  { limit: -0.25, pattern: '--' },
-  { limit: 0.2, pattern: '..' },
-  { limit: 0.6, pattern: '::' },
-  { limit: 1, pattern: '/\\' },
-  { limit: Infinity, pattern: '^^' },
-];
-
-const WORLD_TOPOGRAPHY_RIDGE_PATTERNS = [
-  { limit: 15, pattern: '||' },
-  { limit: 35, pattern: '/\\' },
-  { limit: 70, pattern: '--' },
-  { limit: 110, pattern: '\\/' },
-  { limit: 145, pattern: '\\' },
-  { limit: 180, pattern: '||' },
-];
-
-let cachedTopographyAscii = null;
+function createTopographySvg(){
+  const template = document.createElement('template');
+  template.innerHTML = STATIC_TOPOGRAPHY_SVG.trim();
+  const svg = template.content.firstElementChild;
+  if(svg){
+    svg.setAttribute('aria-hidden', 'true');
+  }
+  return svg;
+}
 
 const MAP_TOPOLOGY_FEATURES = [
   {
@@ -96,11 +144,10 @@ function renderMapMarkers(){
   const map = document.querySelector('#map');
   if(!map) return;
   map.innerHTML = '';
-  const ascii = document.createElement('pre');
-  ascii.className = 'map-topography-ascii';
-  ascii.setAttribute('aria-hidden', 'true');
-  ascii.textContent = generateWorldTopographyAscii();
-  map.appendChild(ascii);
+  const topo = createTopographySvg();
+  if(topo){
+    map.appendChild(topo);
+  }
   const filteredIds = new Set(state.filtered.map(e=>e.id));
   state.entries.filter(e=>e.location).forEach(e=>{
     const marker = document.createElement('button');
@@ -229,125 +276,6 @@ function restoreFromHash(){
     if(e) openModal(e);
   }
 }
-
-function generateWorldTopographyAscii(){
-  if(cachedTopographyAscii) return cachedTopographyAscii;
-  const width = WORLD_TOPOGRAPHY.gridWidth;
-  const height = WORLD_TOPOGRAPHY.gridHeight;
-  const rows = [];
-  for(let gy = 0; gy < height; gy += 1){
-    const py = height <= 1 ? 0 : (gy / (height - 1)) * 100;
-    let row = '';
-    for(let gx = 0; gx < width; gx += 1){
-      const px = width <= 1 ? 0 : (gx / (width - 1)) * 100;
-      const sample = computeWorldTopographySample(px, py);
-      let pattern = pickTopographyPattern(sample);
-      const idx = Math.abs(Math.floor(gx + gy)) % pattern.length;
-      let char = pattern[idx] || pattern[0] || '.';
-      if(sample.elevation > 1.4 && sample.hillInfluence > 0.55 && ((gx + gy) % 5 === 0)){
-        char = 'A';
-      } else if(sample.elevation > 1.75 && sample.hillInfluence > 0.7 && ((gx * 3 + gy) % 7 === 0)){
-        char = 'M';
-      } else if(sample.elevation < -0.85 && sample.valleyInfluence > 0.5 && ((gx + gy * 2) % 4 === 0)){
-        char = 'v';
-      }
-      row += char;
-    }
-    rows.push(row);
-  }
-  cachedTopographyAscii = rows.join('\n');
-  return cachedTopographyAscii;
-}
-
-function computeWorldTopographySample(px, py){
-  let elevation = ((py / 100) - 0.5) * 0.9;
-  elevation += ((px / 100) - 0.5) * 0.4;
-  let hillInfluence = 0;
-  let valleyInfluence = 0;
-  let ridgeInfluence = 0;
-  let ridgeRotation = null;
-  MAP_TOPOLOGY_FEATURES.forEach(feature => {
-    if(!feature) return;
-    const spanX = Math.max(6, Number.isFinite(feature.width) ? feature.width : 20);
-    const spanY = Math.max(6, Number.isFinite(feature.height) ? feature.height : spanX);
-    const dx = px - feature.x;
-    const dy = py - feature.y;
-    const distX = dx / (spanX * 0.5);
-    const distY = dy / (spanY * 0.5);
-    const distance = Math.hypot(distX, distY);
-    if(distance > 2.2) return;
-    const falloff = Math.max(0, 1 - (distance ** 1.35));
-    if(falloff <= 0) return;
-    const intensity = Number.isFinite(feature.intensity) ? feature.intensity : 1;
-    const influence = falloff * intensity;
-    const type = feature.type || 'hill';
-    if(type === 'valley' || type === 'sink'){
-      elevation -= influence * 1.2;
-      valleyInfluence = Math.max(valleyInfluence, influence);
-    } else if(type === 'ridge'){
-      elevation += influence * 0.9;
-      if(influence > ridgeInfluence){
-        ridgeInfluence = influence;
-        ridgeRotation = feature.rotation ?? 0;
-      }
-    } else {
-      elevation += influence * 1.3;
-      hillInfluence = Math.max(hillInfluence, influence);
-      if(influence > ridgeInfluence && Number.isFinite(feature.rotation)){
-        ridgeInfluence = influence * 0.6;
-        ridgeRotation = feature.rotation;
-      }
-    }
-  });
-  const jitter = seededJitter(WORLD_TOPOGRAPHY.seed, px * 1.71 + py * 2.13, 0.55);
-  const drift = seededJitter(WORLD_TOPOGRAPHY.seed, px * -0.42 + py * 0.58, 0.35);
-  elevation += jitter * 0.35 + drift * 0.25;
-  return { elevation, hillInfluence, valleyInfluence, ridgeInfluence, ridgeRotation };
-}
-
-function pickTopographyPattern(sample){
-  if(sample.ridgeInfluence > 0.55 && Number.isFinite(sample.ridgeRotation)){
-    return pickOrientationPattern(sample.ridgeRotation);
-  }
-  if(sample.valleyInfluence > 0.6){
-    return '~~';
-  }
-  let pattern = '::';
-  for(const option of WORLD_TOPOGRAPHY_PALETTE){
-    if(sample.elevation <= option.limit){
-      pattern = option.pattern;
-      break;
-    }
-  }
-  if(sample.hillInfluence > 0.65 && sample.elevation > 0.4){
-    const oriented = Number.isFinite(sample.ridgeRotation)
-      ? pickOrientationPattern(sample.ridgeRotation)
-      : null;
-    if(oriented) pattern = oriented;
-  }
-  return pattern;
-}
-
-function pickOrientationPattern(rotation){
-  const normalized = Math.abs(rotation % 180);
-  for(const option of WORLD_TOPOGRAPHY_RIDGE_PATTERNS){
-    if(normalized <= option.limit){
-      return option.pattern;
-    }
-  }
-  const fallback = WORLD_TOPOGRAPHY_RIDGE_PATTERNS[WORLD_TOPOGRAPHY_RIDGE_PATTERNS.length - 1];
-  return fallback ? fallback.pattern : '||';
-}
-
-function seededRandom(seed, index = 0){
-  const value = Math.sin((seed || 1) * 1337.13 + index * 97.73) * 43758.5453;
-  return value - Math.floor(value);
-}
-
-function seededJitter(seed, index, amplitude = 1){
-  return (seededRandom(seed, index) - 0.5) * 2 * amplitude;
-}
-
 async function main(){
   const res = await fetch('data/entries.json');
   const j = await res.json();

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -25,13 +25,26 @@ button:hover{border-color:var(--accent)}
 .map-wrapper{margin:28px 0;background:linear-gradient(135deg,#10182b,#181f33);border:1px solid var(--line);border-radius:24px;padding:20px;box-shadow:0 14px 32px rgba(0,0,0,.25)}
 .map-header{display:flex;flex-direction:column;gap:4px;margin-bottom:16px}
 .map-header h2{margin:0;font-size:20px}
-.map{position:relative;width:100%;aspect-ratio:16/10;max-height:520px;border:1px solid var(--line);border-radius:18px;background:radial-gradient(circle at 30% 20%, rgba(224,177,65,.25), transparent 45%), radial-gradient(circle at 70% 70%, rgba(111,203,255,.18), transparent 50%), linear-gradient(160deg,#0f1524,#12192a 40%,#10152b 100%);overflow:hidden}
-.map::after{content:'';position:absolute;inset:0;background-image:linear-gradient(0deg,rgba(255,255,255,.05) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.05) 1px,transparent 1px);background-size:14% 14%;opacity:.35;pointer-events:none}
-.marker{position:absolute;transform:translate(-50%,-50%);width:clamp(14px,1.8vw,22px);aspect-ratio:1;border-radius:50%;border:2px solid rgba(255,255,255,.8);background:var(--accent);box-shadow:0 0 0 0 rgba(224,177,65,.6);animation:pulse 3s infinite;cursor:pointer;display:grid;place-items:center}
+.map{position:relative;width:100%;aspect-ratio:20/9;max-height:520px;border:1px solid rgba(124,111,167,.35);border-radius:20px;background:radial-gradient(circle at 22% 18%, rgba(212,175,65,.18), transparent 62%), radial-gradient(circle at 82% 72%, rgba(117,198,255,.18), transparent 60%), linear-gradient(175deg,#0b1120 15%,#0f1628 55%,#080f1d 100%);overflow:hidden;box-shadow:0 22px 46px rgba(0,0,0,.45)}
+.map::before{content:'';position:absolute;inset:6% 8% 12%;background:radial-gradient(circle at 50% 18%, rgba(255,255,255,.14), transparent 70%);filter:blur(28px);opacity:.35;pointer-events:none;z-index:1}
+.map::after{content:'';position:absolute;inset:0;background-image:repeating-linear-gradient(150deg,rgba(255,255,255,.04) 0,rgba(255,255,255,.04) 1px,transparent 1px,transparent 22px),repeating-linear-gradient(30deg,rgba(255,255,255,.035) 0,rgba(255,255,255,.035) 1px,transparent 1px,transparent 22px);opacity:.26;pointer-events:none;z-index:2;mix-blend-mode:screen}
+.map>.map-topography{position:absolute;inset:0;width:100%;height:100%;pointer-events:none;mix-blend-mode:screen;opacity:.95;z-index:1;display:block}
+.map .map-topography .landmass,.map .map-topography .landmass-outline{stroke-linejoin:round;stroke-linecap:round}
+.map .map-topography .landmass{stroke:rgba(88,164,206,.28);stroke-width:4px;fill-opacity:.82}
+.map .map-topography .landmass-outline{stroke:rgba(140,208,248,.24);stroke-width:2.4px;fill-opacity:.94}
+.map .map-topography .contour{fill:none;stroke:rgba(122,198,248,.28);stroke-width:2px;stroke-linecap:round;stroke-linejoin:round}
+.map .map-topography .contour.contour-major{stroke:rgba(126,202,255,.35)}
+.map .map-topography .contour.contour-tight{stroke-width:1.6px;stroke:rgba(154,216,255,.32)}
+.map .map-topography .contour.contour-fine{stroke-width:1.1px;stroke:rgba(164,224,255,.22);stroke-dasharray:14 10}
+.map .map-topography .ridge{fill:none;stroke:url(#terrain-ridge);stroke-width:2.3px;stroke-linecap:round;stroke-linejoin:round;opacity:.75}
+.map .map-topography .river{fill:none;stroke:rgba(102,198,255,.68);stroke-width:3.2px;stroke-linecap:round;stroke-linejoin:round;filter:drop-shadow(0 0 12px rgba(90,180,255,.35))}
+.map .map-topography .lake{fill:rgba(70,144,190,.45);stroke:rgba(140,208,248,.45);stroke-width:1.3px}
+.map .map-topography .glow{fill:none;stroke:rgba(200,228,255,.16);stroke-width:12px;stroke-linecap:round;filter:blur(1.2px)}
+.map .map-topography .island{fill:rgba(38,74,102,.9);stroke:rgba(140,202,236,.4);stroke-width:1.4px}
+.marker{position:absolute;transform:translate(-50%,-50%);width:clamp(14px,1.8vw,22px);aspect-ratio:1;border-radius:50%;border:2px solid rgba(255,255,255,.8);background:var(--accent);box-shadow:0 0 0 0 rgba(224,177,65,.6);animation:pulse 3s infinite;cursor:pointer;display:grid;place-items:center;z-index:3}
 .marker:focus-visible{outline:2px solid #fff;outline-offset:2px}
 .marker span{position:absolute;width:40%;height:40%;border-radius:50%;background:#121622}
 .marker.dim{background:rgba(147,152,172,.65);border-color:rgba(211,214,224,.4);box-shadow:none;animation:none}
-.map-topography-ascii{position:absolute;inset:0;margin:0;padding:8% 6%;font-family:'Fira Code','Source Code Pro','Inconsolata',monospace;font-size:clamp(.36rem,.6vw,.56rem);line-height:1.05;letter-spacing:.06em;white-space:pre;text-align:center;color:rgba(144,196,228,.55);text-shadow:0 0 14px rgba(48,118,176,.24);mix-blend-mode:screen;pointer-events:none;opacity:.92}
 .map-legend{display:flex;gap:16px;flex-wrap:wrap;margin-top:14px;color:var(--muted)}
 .legend-item{display:inline-flex;align-items:center;gap:6px}
 .legend-dot{width:10px;height:10px;border-radius:50%;background:var(--accent);border:1px solid rgba(255,255,255,.8)}


### PR DESCRIPTION
## Summary
- replace the procedurally generated ASCII terrain with a hand-crafted SVG topography layer rich in contour, ridge, and river detail
- restyle the atlas map container to showcase the new contours, water features, and highlights in both the app and docs builds
- ensure the GitHub Pages build mirrors the new static map layer so markers render above the updated artwork

## Testing
- Visual inspection of http://127.0.0.1:8000/ (Playwright screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68dea6be7a90832291738c79f9bbfbc3