### PR TITLE
Remove decorative map overlays

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -501,81 +501,6 @@ const TOPOLOGY_FEATURE_MAP = new Map(
   MAP_TOPOLOGY_FEATURES.map(feature => [feature.id, feature])
 );
 
-const STATIC_TOPOGRAPHY_SVG = `
-  <svg class="map-topography" viewBox="0 0 1200 720" preserveAspectRatio="xMidYMid slice" aria-hidden="true" focusable="false">
-    <defs>
-      <linearGradient id="terrain-water" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#071018"/>
-        <stop offset="55%" stop-color="#0b1826"/>
-        <stop offset="100%" stop-color="#050b13"/>
-      </linearGradient>
-      <radialGradient id="terrain-glow" cx="52%" cy="38%" r="62%">
-        <stop offset="0%" stop-color="#1f3b54" stop-opacity="0.9"/>
-        <stop offset="60%" stop-color="#142941" stop-opacity="0.8"/>
-        <stop offset="100%" stop-color="#0b1826" stop-opacity="0.7"/>
-      </radialGradient>
-      <linearGradient id="terrain-fill" x1="32%" y1="12%" x2="78%" y2="88%">
-        <stop offset="0%" stop-color="#1f3951"/>
-        <stop offset="40%" stop-color="#203c4c"/>
-        <stop offset="100%" stop-color="#122332"/>
-      </linearGradient>
-      <linearGradient id="terrain-ridge" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" stop-color="#3d8fb6" stop-opacity="0.85"/>
-        <stop offset="50%" stop-color="#6abbe0" stop-opacity="0.8"/>
-        <stop offset="100%" stop-color="#3682ab" stop-opacity="0.85"/>
-      </linearGradient>
-      <filter id="terrain-haze" x="-15%" y="-15%" width="130%" height="130%">
-        <feGaussianBlur stdDeviation="18" result="blur"/>
-        <feBlend in="blur" in2="SourceGraphic" mode="screen"/>
-      </filter>
-    </defs>
-    <rect width="1200" height="720" fill="url(#terrain-water)"/>
-    <g class="land" filter="url(#terrain-haze)">
-      <path class="landmass" d="M132 484C134 356 244 272 398 242C512 220 624 170 734 182C850 196 938 262 970 338C1004 418 956 508 890 566C822 626 712 642 610 616C520 594 462 618 376 610C268 600 168 564 132 484Z" fill="url(#terrain-glow)"/>
-      <path class="landmass-outline" d="M152 470C154 366 250 292 396 262C500 240 612 188 722 198C826 208 904 266 932 330C962 396 926 472 868 524C812 576 710 596 618 574C520 550 462 574 384 566C288 556 190 528 152 470Z" fill="url(#terrain-fill)"/>
-    </g>
-    <g class="contours">
-      <path class="contour contour-major" d="M188 470C198 382 296 320 428 292C528 270 622 238 708 248C782 256 846 288 876 338C912 398 874 466 822 516C770 566 688 584 604 564C520 544 462 566 394 558C306 548 224 520 188 470Z"/>
-      <path class="contour contour-major" d="M236 470C248 396 320 348 430 320C512 300 596 276 674 286C734 294 786 320 810 356C842 404 812 458 770 496C726 536 656 548 586 532C514 516 460 534 400 526C324 516 266 502 236 470Z"/>
-      <path class="contour contour-tight" d="M292 468C304 410 360 368 448 348C520 332 586 320 642 330C688 338 726 356 742 382C764 420 740 456 706 486C670 516 612 524 556 510C502 496 460 510 410 502C356 494 312 486 292 468Z"/>
-      <path class="contour contour-tight" d="M338 468C348 426 394 392 460 378C516 366 570 360 612 368C646 374 676 388 688 410C704 438 686 466 660 490C632 514 584 520 540 506C494 492 458 504 420 498C380 492 350 484 338 468Z"/>
-      <path class="contour contour-fine" d="M382 470C390 440 424 414 474 404C514 396 552 392 586 398C612 402 636 414 644 430C656 452 642 474 620 494C596 514 560 518 526 508C494 498 462 508 432 504C406 500 390 490 382 470Z"/>
-      <path class="contour contour-fine" d="M430 470C438 448 464 432 500 426C530 422 560 420 582 424C602 428 620 438 626 450C636 468 624 486 604 500C582 516 552 518 526 508C502 500 474 510 450 506C438 504 432 492 430 470Z"/>
-      <path class="contour contour-major" d="M322 404C350 352 420 314 510 300C580 290 642 292 694 304C742 314 782 338 802 366"/>
-      <path class="contour contour-fine" d="M264 426C292 366 366 320 468 304"/>
-      <path class="contour contour-fine" d="M526 286C582 276 648 276 698 286"/>
-    </g>
-    <g class="ridges">
-      <path class="ridge" d="M332 344C378 310 454 286 544 278C626 270 710 284 772 320"/>
-      <path class="ridge" d="M364 310C430 268 536 244 640 250C706 254 764 272 806 298"/>
-    </g>
-    <g class="waterways">
-      <path class="river" d="M520 520C552 486 562 452 560 418C558 374 582 338 636 312"/>
-      <path class="river" d="M468 496C500 462 506 426 498 390"/>
-      <path class="lake" d="M646 370C662 354 692 348 712 360C732 372 732 396 716 414C700 432 666 438 648 424C632 412 630 388 646 370Z"/>
-      <path class="lake" d="M424 432C438 420 460 416 476 424C492 432 492 450 478 462C464 474 440 478 426 468C414 460 412 444 424 432Z"/>
-    </g>
-    <g class="highlights">
-      <path class="glow" d="M300 516C360 556 452 578 548 576C644 574 720 548 786 494"/>
-      <path class="glow" d="M248 448C292 378 380 326 496 310"/>
-    </g>
-    <g class="islands">
-      <path class="island" d="M968 420C984 404 1008 398 1028 406C1048 414 1052 432 1038 446C1024 460 996 466 978 456C962 448 954 434 968 420Z"/>
-      <path class="island" d="M204 308C214 296 234 292 250 298C266 304 268 320 256 332C244 344 222 348 208 340C196 334 194 320 204 308Z"/>
-    </g>
-  </svg>
-`;
-
-function createTopographySvg(){
-  const template = document.createElement('template');
-  template.innerHTML = STATIC_TOPOGRAPHY_SVG.trim();
-  const svg = template.content.firstElementChild;
-  if(svg){
-    svg.setAttribute('aria-hidden', 'true');
-  }
-  return svg;
-}
-
 const NPCS = [
   {
     id: 'archivist-sel',
@@ -2038,13 +1963,6 @@ function ensureMapStructure(){
   world.className = 'map-world';
   world.style.setProperty('--map-world-size', `${(MAP_WORLD_SCALE * 100).toFixed(0)}%`);
   viewport.appendChild(world);
-  const topographyLayer = document.createElement('div');
-  topographyLayer.className = 'map-layer map-layer-topography';
-  topographyLayer.setAttribute('aria-hidden', 'true');
-  const topographySvg = createTopographySvg();
-  if(topographySvg){
-    topographyLayer.appendChild(topographySvg);
-  }
   const pathSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   pathSvg.classList.add('map-path');
   pathSvg.setAttribute('viewBox', '0 0 100 100');
@@ -2064,7 +1982,7 @@ function ensureMapStructure(){
   npcLayer.className = 'map-layer map-layer-npcs';
   const actorsLayer = document.createElement('div');
   actorsLayer.className = 'map-layer map-layer-actors';
-  world.append(topographyLayer, pathSvg, zonesLayer, markersLayer, eventsLayer, npcLayer, actorsLayer);
+  world.append(pathSvg, zonesLayer, markersLayer, eventsLayer, npcLayer, actorsLayer);
   map.appendChild(viewport);
   const detail = document.createElement('div');
   detail.id = 'map-zone-detail';
@@ -2083,7 +2001,6 @@ function ensureMapStructure(){
   map._layers = {
     viewport,
     world,
-    topography: { layer: topographyLayer, svg: topographySvg },
     path: { svg: pathSvg, line: pathLine },
     zones: zonesLayer,
     markers: markersLayer,
@@ -2262,117 +2179,6 @@ function generateZoneClipPath(zone, features = resolveZoneFeatures(zone)){
   return `polygon(${points.join(', ')})`;
 }
 
-function computeZoneOrientation(zone, features = resolveZoneFeatures(zone)){
-  if(!zone || !features.length) return null;
-  let sumX = 0;
-  let sumY = 0;
-  features.forEach(({ feature, weight }) => {
-    if(!feature) return;
-    const fx = feature.x - zone.x;
-    const fy = feature.y - zone.y;
-    if(!Number.isFinite(fx) || !Number.isFinite(fy) || (fx === 0 && fy === 0)) return;
-    const type = feature.type || 'hill';
-    const sign = (type === 'valley' || type === 'sink') ? -1 : (type === 'ridge' ? 0.6 : 1);
-    const influenceWeight = (Number.isFinite(weight) ? weight : 1) * sign;
-    sumX += fx * influenceWeight;
-    sumY += fy * influenceWeight;
-  });
-  if(sumX === 0 && sumY === 0) return null;
-  const angle = Math.atan2(sumY, sumX) * (180 / Math.PI);
-  return (angle + 360) % 360;
-}
-
-function generateZoneAsciiArt(zone, orientation){
-  const width = Number.isFinite(zone?.width) ? zone.width : 36;
-  const height = Number.isFinite(zone?.height) ? zone.height : width;
-  const gridWidth = clampNumber(Math.round(width / 2.4), 12, 22);
-  const gridHeight = clampNumber(Math.round(height / 3.4), 6, 12);
-  const normalizedOrientation = Number.isFinite(orientation)
-    ? Math.abs(orientation % 180)
-    : null;
-  const orientationPatterns = [
-    { limit: 22.5, pattern: '==' },
-    { limit: 52.5, pattern: '/\\' },
-    { limit: 82.5, pattern: '\\' },
-    { limit: 112.5, pattern: '||' },
-    { limit: 142.5, pattern: '\\/' },
-    { limit: 180, pattern: '..' },
-  ];
-  let fillPattern = '..';
-  if(normalizedOrientation !== null){
-    for(const option of orientationPatterns){
-      if(normalizedOrientation <= option.limit){
-        fillPattern = option.pattern;
-        break;
-      }
-    }
-  }
-  const seed = computeZoneSeedValue(zone);
-  const fillVariations = ['..', '--', '::', '~~', '<>', '**'];
-  if(fillPattern === '..'){
-    const variantIndex = Math.floor((Math.abs(seed) * 37) % fillVariations.length);
-    fillPattern = fillVariations[variantIndex] || '..';
-  }
-  const patternChars = fillPattern.split('');
-  const rows = [];
-  for(let y = 0; y < gridHeight; y += 1){
-    const progress = gridHeight <= 1 ? 0 : y / (gridHeight - 1);
-    const bulge = Math.sin(progress * Math.PI);
-    const wave = seededJitter(seed, y * 1.7, 0.35);
-    const offset = seededJitter(seed, y + 24.1, 1.4);
-    const center = gridWidth / 2 + offset;
-    let radius = (gridWidth / 3) + bulge * (gridWidth / 2.8) + wave * (gridWidth / 3.6);
-    radius = Math.max(2.2, radius);
-    let start = Math.max(0, Math.floor(center - radius));
-    let end = Math.min(gridWidth - 1, Math.ceil(center + radius));
-    if(end - start < 3){
-      const adjust = 3 - (end - start);
-      start = Math.max(0, start - Math.ceil(adjust / 2));
-      end = Math.min(gridWidth - 1, end + Math.floor(adjust / 2));
-    }
-    let row = '';
-    for(let x = 0; x < gridWidth; x += 1){
-      if(x < start || x > end){
-        row += ' ';
-        continue;
-      }
-      const isEdge = (x === start || x === end);
-      if(isEdge){
-        const slope = seededJitter(seed, x * 0.6 + y * 0.8, 0.9);
-        const isTop = y === 0;
-        const isBottom = y === gridHeight - 1;
-        let edgeChar = '|';
-        if(isTop){
-          edgeChar = x === start ? '/' : '\\';
-        } else if(isBottom){
-          edgeChar = x === start ? '\\' : '/';
-        } else if(slope > 0.45){
-          edgeChar = ')';
-        } else if(slope < -0.45){
-          edgeChar = '(';
-        } else if(slope > 0){
-          edgeChar = ']';
-        } else {
-          edgeChar = '[';
-        }
-        row += edgeChar;
-      } else {
-        const index = Math.abs(Math.floor((x + y + seed) % patternChars.length));
-        let fillChar = patternChars[index] || '.';
-        const sparkle = seededRandom(seed, x * 5.7 + y * 3.9);
-        if(sparkle > 0.94){
-          const accents = ['*', '.', ':', "'"];
-          const accent = accents[Math.floor(seededRandom(seed, x * 2.6 + y * 1.8) * accents.length)];
-          if(accent) fillChar = accent;
-        }
-        row += fillChar;
-      }
-    }
-    rows.push(row.replace(/\s+$/u, ''));
-  }
-  return rows.join('\n').replace(/\s+$/gmu, '');
-}
-
 function renderMapZones(layer){
   ensureMapStructure();
   if(!layer) return;
@@ -2409,17 +2215,6 @@ function renderMapZones(layer){
       zoneEl.style.removeProperty('clip-path');
       zoneEl.style.removeProperty('-webkit-clip-path');
     }
-    const orientation = computeZoneOrientation(zone, zoneFeatures);
-    if(Number.isFinite(orientation)){
-      zoneEl.style.setProperty('--zone-orientation', `${orientation.toFixed(1)}deg`);
-    } else {
-      zoneEl.style.removeProperty('--zone-orientation');
-    }
-    const ascii = document.createElement('pre');
-    ascii.className = 'map-zone-ascii';
-    ascii.setAttribute('aria-hidden', 'true');
-    ascii.textContent = generateZoneAsciiArt(zone, orientation);
-    zoneEl.appendChild(ascii);
     zoneEl.dataset.zoneName = zone.name;
     const label = document.createElement('div');
     label.className = 'map-zone-label';

--- a/assets/style.css
+++ b/assets/style.css
@@ -644,100 +644,6 @@ button:hover, .badge:hover {
   z-index: 3;
 }
 
-.map-layer-topography {
-  z-index: 1;
-  opacity: 0.95;
-}
-
-.map-layer-topography .map-topography {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  display: block;
-  pointer-events: none;
-  mix-blend-mode: screen;
-}
-
-.map-topography .landmass,
-.map-topography .landmass-outline {
-  stroke-linejoin: round;
-  stroke-linecap: round;
-}
-
-.map-topography .landmass {
-  stroke: rgba(88, 164, 206, 0.28);
-  stroke-width: 4px;
-  fill-opacity: 0.82;
-}
-
-.map-topography .landmass-outline {
-  stroke: rgba(140, 208, 248, 0.24);
-  stroke-width: 2.4px;
-  fill-opacity: 0.94;
-}
-
-.map-topography .contour {
-  fill: none;
-  stroke: rgba(122, 198, 248, 0.28);
-  stroke-width: 2px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.map-topography .contour.contour-major {
-  stroke: rgba(126, 202, 255, 0.35);
-}
-
-.map-topography .contour.contour-tight {
-  stroke-width: 1.6px;
-  stroke: rgba(154, 216, 255, 0.32);
-}
-
-.map-topography .contour.contour-fine {
-  stroke-width: 1.1px;
-  stroke: rgba(164, 224, 255, 0.22);
-  stroke-dasharray: 14 10;
-}
-
-.map-topography .ridge {
-  fill: none;
-  stroke: url(#terrain-ridge);
-  stroke-width: 2.3px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  opacity: 0.75;
-}
-
-.map-topography .river {
-  fill: none;
-  stroke: rgba(102, 198, 255, 0.68);
-  stroke-width: 3.2px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  filter: drop-shadow(0 0 12px rgba(90, 180, 255, 0.35));
-}
-
-.map-topography .lake {
-  fill: rgba(70, 144, 190, 0.45);
-  stroke: rgba(140, 208, 248, 0.45);
-  stroke-width: 1.3px;
-}
-
-.map-topography .glow {
-  fill: none;
-  stroke: rgba(200, 228, 255, 0.16);
-  stroke-width: 12px;
-  stroke-linecap: round;
-  filter: blur(1.2px);
-}
-
-.map-topography .island {
-  fill: rgba(38, 74, 102, 0.9);
-  stroke: rgba(140, 202, 236, 0.4);
-  stroke-width: 1.4px;
-}
-
 
 .map-layer-zones {
   z-index: 3;
@@ -886,7 +792,6 @@ button:hover, .badge:hover {
 .map-zone {
   position: absolute;
   transform: translate(-50%, -50%);
-  --zone-orientation: 128deg;
   --zone-clip: ellipse(50% 44% at 50% 50%);
   clip-path: var(--zone-clip);
   -webkit-clip-path: var(--zone-clip);
@@ -901,26 +806,6 @@ button:hover, .badge:hover {
   transition: color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, transform 0.35s ease;
 }
 
-.map-zone-ascii {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 6%;
-  font-family: 'Fira Code', 'Source Code Pro', 'Inconsolata', monospace;
-  font-size: clamp(0.42rem, 0.8vw, 0.62rem);
-  line-height: 1.1;
-  letter-spacing: 0.08em;
-  white-space: pre;
-  text-align: center;
-  color: currentColor;
-  text-shadow: 0 0 14px rgba(212, 175, 55, 0.18);
-  pointer-events: none;
-  opacity: 0.38;
-  mix-blend-mode: screen;
-}
-
 .map-zone.active {
   color: rgba(232, 227, 211, 0.82);
   border-color: rgba(212, 175, 55, 0.58);
@@ -933,16 +818,6 @@ button:hover, .badge:hover {
   border-color: rgba(212, 175, 55, 0.75);
   box-shadow: 0 22px 54px rgba(212, 175, 55, 0.35);
   transform: translate(-50%, -50%) scale(1.07);
-}
-
-.map-zone.active .map-zone-ascii {
-  opacity: 0.62;
-  text-shadow: 0 0 18px rgba(212, 175, 55, 0.26);
-}
-
-.map-zone.selected .map-zone-ascii {
-  opacity: 0.78;
-  text-shadow: 0 0 22px rgba(212, 175, 55, 0.4);
 }
 
 .map-zone.active .map-zone-label {

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -7,81 +7,6 @@ const state = {
   tag: 'All',
 };
 
-const STATIC_TOPOGRAPHY_SVG = `
-  <svg class="map-topography" viewBox="0 0 1200 720" preserveAspectRatio="xMidYMid slice" aria-hidden="true" focusable="false">
-    <defs>
-      <linearGradient id="terrain-water" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#071018"/>
-        <stop offset="55%" stop-color="#0b1826"/>
-        <stop offset="100%" stop-color="#050b13"/>
-      </linearGradient>
-      <radialGradient id="terrain-glow" cx="52%" cy="38%" r="62%">
-        <stop offset="0%" stop-color="#1f3b54" stop-opacity="0.9"/>
-        <stop offset="60%" stop-color="#142941" stop-opacity="0.8"/>
-        <stop offset="100%" stop-color="#0b1826" stop-opacity="0.7"/>
-      </radialGradient>
-      <linearGradient id="terrain-fill" x1="32%" y1="12%" x2="78%" y2="88%">
-        <stop offset="0%" stop-color="#1f3951"/>
-        <stop offset="40%" stop-color="#203c4c"/>
-        <stop offset="100%" stop-color="#122332"/>
-      </linearGradient>
-      <linearGradient id="terrain-ridge" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" stop-color="#3d8fb6" stop-opacity="0.85"/>
-        <stop offset="50%" stop-color="#6abbe0" stop-opacity="0.8"/>
-        <stop offset="100%" stop-color="#3682ab" stop-opacity="0.85"/>
-      </linearGradient>
-      <filter id="terrain-haze" x="-15%" y="-15%" width="130%" height="130%">
-        <feGaussianBlur stdDeviation="18" result="blur"/>
-        <feBlend in="blur" in2="SourceGraphic" mode="screen"/>
-      </filter>
-    </defs>
-    <rect width="1200" height="720" fill="url(#terrain-water)"/>
-    <g class="land" filter="url(#terrain-haze)">
-      <path class="landmass" d="M132 484C134 356 244 272 398 242C512 220 624 170 734 182C850 196 938 262 970 338C1004 418 956 508 890 566C822 626 712 642 610 616C520 594 462 618 376 610C268 600 168 564 132 484Z" fill="url(#terrain-glow)"/>
-      <path class="landmass-outline" d="M152 470C154 366 250 292 396 262C500 240 612 188 722 198C826 208 904 266 932 330C962 396 926 472 868 524C812 576 710 596 618 574C520 550 462 574 384 566C288 556 190 528 152 470Z" fill="url(#terrain-fill)"/>
-    </g>
-    <g class="contours">
-      <path class="contour contour-major" d="M188 470C198 382 296 320 428 292C528 270 622 238 708 248C782 256 846 288 876 338C912 398 874 466 822 516C770 566 688 584 604 564C520 544 462 566 394 558C306 548 224 520 188 470Z"/>
-      <path class="contour contour-major" d="M236 470C248 396 320 348 430 320C512 300 596 276 674 286C734 294 786 320 810 356C842 404 812 458 770 496C726 536 656 548 586 532C514 516 460 534 400 526C324 516 266 502 236 470Z"/>
-      <path class="contour contour-tight" d="M292 468C304 410 360 368 448 348C520 332 586 320 642 330C688 338 726 356 742 382C764 420 740 456 706 486C670 516 612 524 556 510C502 496 460 510 410 502C356 494 312 486 292 468Z"/>
-      <path class="contour contour-tight" d="M338 468C348 426 394 392 460 378C516 366 570 360 612 368C646 374 676 388 688 410C704 438 686 466 660 490C632 514 584 520 540 506C494 492 458 504 420 498C380 492 350 484 338 468Z"/>
-      <path class="contour contour-fine" d="M382 470C390 440 424 414 474 404C514 396 552 392 586 398C612 402 636 414 644 430C656 452 642 474 620 494C596 514 560 518 526 508C494 498 462 508 432 504C406 500 390 490 382 470Z"/>
-      <path class="contour contour-fine" d="M430 470C438 448 464 432 500 426C530 422 560 420 582 424C602 428 620 438 626 450C636 468 624 486 604 500C582 516 552 518 526 508C502 500 474 510 450 506C438 504 432 492 430 470Z"/>
-      <path class="contour contour-major" d="M322 404C350 352 420 314 510 300C580 290 642 292 694 304C742 314 782 338 802 366"/>
-      <path class="contour contour-fine" d="M264 426C292 366 366 320 468 304"/>
-      <path class="contour contour-fine" d="M526 286C582 276 648 276 698 286"/>
-    </g>
-    <g class="ridges">
-      <path class="ridge" d="M332 344C378 310 454 286 544 278C626 270 710 284 772 320"/>
-      <path class="ridge" d="M364 310C430 268 536 244 640 250C706 254 764 272 806 298"/>
-    </g>
-    <g class="waterways">
-      <path class="river" d="M520 520C552 486 562 452 560 418C558 374 582 338 636 312"/>
-      <path class="river" d="M468 496C500 462 506 426 498 390"/>
-      <path class="lake" d="M646 370C662 354 692 348 712 360C732 372 732 396 716 414C700 432 666 438 648 424C632 412 630 388 646 370Z"/>
-      <path class="lake" d="M424 432C438 420 460 416 476 424C492 432 492 450 478 462C464 474 440 478 426 468C414 460 412 444 424 432Z"/>
-    </g>
-    <g class="highlights">
-      <path class="glow" d="M300 516C360 556 452 578 548 576C644 574 720 548 786 494"/>
-      <path class="glow" d="M248 448C292 378 380 326 496 310"/>
-    </g>
-    <g class="islands">
-      <path class="island" d="M968 420C984 404 1008 398 1028 406C1048 414 1052 432 1038 446C1024 460 996 466 978 456C962 448 954 434 968 420Z"/>
-      <path class="island" d="M204 308C214 296 234 292 250 298C266 304 268 320 256 332C244 344 222 348 208 340C196 334 194 320 204 308Z"/>
-    </g>
-  </svg>
-`;
-
-function createTopographySvg(){
-  const template = document.createElement('template');
-  template.innerHTML = STATIC_TOPOGRAPHY_SVG.trim();
-  const svg = template.content.firstElementChild;
-  if(svg){
-    svg.setAttribute('aria-hidden', 'true');
-  }
-  return svg;
-}
-
 const MAP_TOPOLOGY_FEATURES = [
   {
     id: 'choir-uplands',
@@ -144,10 +69,6 @@ function renderMapMarkers(){
   const map = document.querySelector('#map');
   if(!map) return;
   map.innerHTML = '';
-  const topo = createTopographySvg();
-  if(topo){
-    map.appendChild(topo);
-  }
   const filteredIds = new Set(state.filtered.map(e=>e.id));
   state.entries.filter(e=>e.location).forEach(e=>{
     const marker = document.createElement('button');

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -28,19 +28,6 @@ button:hover{border-color:var(--accent)}
 .map{position:relative;width:100%;aspect-ratio:20/9;max-height:520px;border:1px solid rgba(124,111,167,.35);border-radius:20px;background:radial-gradient(circle at 22% 18%, rgba(212,175,65,.18), transparent 62%), radial-gradient(circle at 82% 72%, rgba(117,198,255,.18), transparent 60%), linear-gradient(175deg,#0b1120 15%,#0f1628 55%,#080f1d 100%);overflow:hidden;box-shadow:0 22px 46px rgba(0,0,0,.45)}
 .map::before{content:'';position:absolute;inset:6% 8% 12%;background:radial-gradient(circle at 50% 18%, rgba(255,255,255,.14), transparent 70%);filter:blur(28px);opacity:.35;pointer-events:none;z-index:1}
 .map::after{content:'';position:absolute;inset:0;background-image:repeating-linear-gradient(150deg,rgba(255,255,255,.04) 0,rgba(255,255,255,.04) 1px,transparent 1px,transparent 22px),repeating-linear-gradient(30deg,rgba(255,255,255,.035) 0,rgba(255,255,255,.035) 1px,transparent 1px,transparent 22px);opacity:.26;pointer-events:none;z-index:2;mix-blend-mode:screen}
-.map>.map-topography{position:absolute;inset:0;width:100%;height:100%;pointer-events:none;mix-blend-mode:screen;opacity:.95;z-index:1;display:block}
-.map .map-topography .landmass,.map .map-topography .landmass-outline{stroke-linejoin:round;stroke-linecap:round}
-.map .map-topography .landmass{stroke:rgba(88,164,206,.28);stroke-width:4px;fill-opacity:.82}
-.map .map-topography .landmass-outline{stroke:rgba(140,208,248,.24);stroke-width:2.4px;fill-opacity:.94}
-.map .map-topography .contour{fill:none;stroke:rgba(122,198,248,.28);stroke-width:2px;stroke-linecap:round;stroke-linejoin:round}
-.map .map-topography .contour.contour-major{stroke:rgba(126,202,255,.35)}
-.map .map-topography .contour.contour-tight{stroke-width:1.6px;stroke:rgba(154,216,255,.32)}
-.map .map-topography .contour.contour-fine{stroke-width:1.1px;stroke:rgba(164,224,255,.22);stroke-dasharray:14 10}
-.map .map-topography .ridge{fill:none;stroke:url(#terrain-ridge);stroke-width:2.3px;stroke-linecap:round;stroke-linejoin:round;opacity:.75}
-.map .map-topography .river{fill:none;stroke:rgba(102,198,255,.68);stroke-width:3.2px;stroke-linecap:round;stroke-linejoin:round;filter:drop-shadow(0 0 12px rgba(90,180,255,.35))}
-.map .map-topography .lake{fill:rgba(70,144,190,.45);stroke:rgba(140,208,248,.45);stroke-width:1.3px}
-.map .map-topography .glow{fill:none;stroke:rgba(200,228,255,.16);stroke-width:12px;stroke-linecap:round;filter:blur(1.2px)}
-.map .map-topography .island{fill:rgba(38,74,102,.9);stroke:rgba(140,202,236,.4);stroke-width:1.4px}
 .marker{position:absolute;transform:translate(-50%,-50%);width:clamp(14px,1.8vw,22px);aspect-ratio:1;border-radius:50%;border:2px solid rgba(255,255,255,.8);background:var(--accent);box-shadow:0 0 0 0 rgba(224,177,65,.6);animation:pulse 3s infinite;cursor:pointer;display:grid;place-items:center;z-index:3}
 .marker:focus-visible{outline:2px solid #fff;outline-offset:2px}
 .marker span{position:absolute;width:40%;height:40%;border-radius:50%;background:#121622}


### PR DESCRIPTION
## Summary
- remove the scripted topography layer from the map and stop appending the SVG overlay
- drop ASCII art rendering for zones and tidy associated styles
- mirror the overlay removals in the prebuilt docs assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb285c7fc8322bf51ea21f7a00433