### PR TITLE
Add cross-linked specimen relationships

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2028,6 +2028,118 @@ button:hover, .badge:hover {
   color: var(--ink);
 }
 
+.entry-connections {
+  margin-top: 24px;
+  display: grid;
+  gap: 20px;
+}
+
+.entry-connections > h3 {
+  margin: 0;
+  font-size: 1.3rem;
+  letter-spacing: 0.08rem;
+  text-transform: uppercase;
+  font-family: 'Inconsolata', monospace;
+  color: var(--accent-gold);
+}
+
+.connection-group {
+  padding: 18px 20px;
+  border-radius: 18px;
+  border: 1px solid rgba(124, 111, 167, 0.35);
+  background: rgba(12, 17, 32, 0.85);
+  box-shadow: inset 0 0 24px rgba(124, 111, 167, 0.12);
+}
+
+.connection-group h4 {
+  margin: 0;
+  font-size: 1.02rem;
+  color: var(--accent-gold);
+  letter-spacing: 0.08rem;
+  text-transform: uppercase;
+  font-family: 'Inconsolata', monospace;
+}
+
+.connection-description {
+  margin: 6px 0 0;
+}
+
+.connection-list {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.connection-item {
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(124, 111, 167, 0.3);
+  background: rgba(10, 14, 28, 0.78);
+  display: grid;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.connection-item.npc {
+  border-color: rgba(212, 175, 55, 0.4);
+}
+
+.connection-item.event {
+  border-style: dashed;
+  border-color: rgba(124, 111, 167, 0.45);
+}
+
+.connection-item.event.active {
+  border-color: rgba(212, 175, 55, 0.65);
+  box-shadow: 0 0 18px rgba(212, 175, 55, 0.2);
+}
+
+.relation-link {
+  background: none;
+  border: none;
+  color: var(--accent-gold);
+  font-family: 'Inconsolata', monospace;
+  font-size: 0.95rem;
+  letter-spacing: 0.06rem;
+  text-transform: uppercase;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+  transition: color 0.2s ease, text-shadow 0.2s ease;
+}
+
+.relation-link:hover,
+.relation-link:focus {
+  color: var(--ink);
+  text-shadow: 0 0 12px rgba(212, 175, 55, 0.4);
+  outline: none;
+}
+
+.connection-label {
+  font-family: 'Inconsolata', monospace;
+  letter-spacing: 0.08rem;
+  text-transform: uppercase;
+}
+
+.connection-note {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.connection-meta {
+  font-family: 'Inconsolata', monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.08rem;
+  text-transform: uppercase;
+  color: rgba(212, 175, 55, 0.75);
+}
+
+.connection-item.event .connection-meta {
+  color: rgba(124, 111, 167, 0.75);
+}
+
 hr {
   border: none;
   border-top: 1px solid rgba(124, 111, 167, 0.35);


### PR DESCRIPTION
## Summary
- build a cross-reference index so specimens surface related tags, regions, variants, NPC ties, and ambient events
- extend the catalogue modal to render the new linkage groups with interactive navigation to entries and NPC dossiers
- style the linkage sections to match the archive aesthetic and seed NPC linkage data during boot

## Testing
- node --check assets/app.js

------
https://chatgpt.com/codex/tasks/task_e_68df0f2a2c2083229c406bfd83cf980a