### PR TITLE
Add landmark buildings and NPC hangouts to atlas

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -649,6 +649,15 @@ button:hover, .badge:hover {
   z-index: 3;
 }
 
+.map-layer-buildings {
+  z-index: 4;
+  pointer-events: none;
+}
+
+.map-layer-buildings .marker {
+  pointer-events: auto;
+}
+
 .map-layer-markers {
   z-index: 5;
 }
@@ -658,7 +667,7 @@ button:hover, .badge:hover {
 }
 
 .map-layer-events {
-  z-index: 5;
+  z-index: 6;
 }
 
 .map-layer-events .map-event {
@@ -745,7 +754,7 @@ button:hover, .badge:hover {
 }
 
 .map-layer-npcs {
-  z-index: 5;
+  z-index: 7;
   pointer-events: none;
 }
 
@@ -754,7 +763,7 @@ button:hover, .badge:hover {
 }
 
 .map-layer-actors {
-  z-index: 6;
+  z-index: 8;
 }
 
 .map-path {
@@ -1083,7 +1092,7 @@ button:hover, .badge:hover {
   z-index: 2;
 }
 
-.marker span {
+.marker:not(.building) span {
   position: absolute;
   width: 48%;
   height: 48%;
@@ -1126,6 +1135,45 @@ button:hover, .badge:hover {
   box-shadow: 0 0 0 0 rgba(99, 240, 255, 0.65);
 }
 
+.marker.building {
+  min-width: clamp(16px, 2.2vw, 24px);
+  width: auto;
+  height: clamp(12px, 1.8vw, 20px);
+  aspect-ratio: initial;
+  padding: 2px 6px;
+  border-radius: 8px;
+  border: 1px solid rgba(180, 210, 255, 0.65);
+  background: linear-gradient(180deg, rgba(74, 116, 196, 0.92), rgba(32, 56, 118, 0.88));
+  box-shadow: 0 0 14px rgba(74, 116, 196, 0.35);
+  animation: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Inconsolata', monospace;
+  font-size: clamp(0.48rem, 0.75vw, 0.68rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(233, 244, 255, 0.92);
+}
+
+.marker.building .marker-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1px 4px;
+  border-radius: 6px;
+  border: 1px solid rgba(210, 226, 255, 0.4);
+  background: rgba(12, 18, 36, 0.45);
+  box-shadow: inset 0 0 8px rgba(38, 62, 112, 0.6);
+  min-width: 18px;
+}
+
+.marker.building:hover,
+.marker.building:focus-visible {
+  box-shadow: 0 0 18px rgba(102, 154, 246, 0.55);
+  border-color: rgba(218, 232, 255, 0.9);
+}
+
 .map-legend {
   display: flex;
   gap: 14px;
@@ -1153,6 +1201,15 @@ button:hover, .badge:hover {
 .legend-dot.character {
   background: linear-gradient(180deg, #63f0ff, #1f9bff);
   border-color: rgba(233, 248, 255, 0.9);
+}
+
+.legend-dot.building {
+  width: 10px;
+  height: 6px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, rgba(74, 116, 196, 0.9), rgba(32, 56, 118, 0.88));
+  border-color: rgba(188, 210, 255, 0.85);
+  box-shadow: 0 0 8px rgba(86, 132, 210, 0.45);
 }
 
 .legend-dot.npc-new {
@@ -1466,6 +1523,23 @@ button:hover, .badge:hover {
   border-radius: 999px;
   border: 1px solid rgba(124, 111, 167, 0.4);
   background: rgba(12, 17, 32, 0.65);
+}
+
+.npc-meta .npc-building {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(82, 142, 226, 0.4);
+  background: rgba(20, 32, 62, 0.6);
+  color: rgba(210, 224, 255, 0.82);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.npc-meta .npc-building::before {
+  content: '◆';
+  font-size: 0.6rem;
+  color: rgba(162, 196, 255, 0.9);
 }
 
 .npc-meta .npc-location {

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
             <div id="map" class="map" role="img" aria-label="Stylised map of the Dreamless Kingdom with flora markers"></div>
             <div class="map-legend small">
               <span class="legend-item"><span class="legend-dot"></span> Discoverable specimen</span>
+              <span class="legend-item"><span class="legend-dot building"></span> Landmark building</span>
               <span class="legend-item"><span class="legend-dot character"></span> NPC contact</span>
               <span class="legend-item"><span class="legend-dot npc-new"></span> NPC with new dialogue</span>
               <span class="legend-item"><span class="legend-dot dim"></span> Outside current filters</span>


### PR DESCRIPTION
## Summary
- add landmark building definitions and render them as distinct markers on the atlas
- surface building spotlights and adjust NPC locations to linger near their associated landmarks
- update styles, legend, and villager details to highlight building associations

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68df146abfd88322875e514ff0e96dde